### PR TITLE
Fixes build on windows msvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,27 +191,27 @@ _(Note: The `const_extractor` path and the exact location of the workspace `Carg
       - Generate Rust FFI bindings (`bindings.rs`) using `bindgen` against `rust/wxdragon-sys/cpp/include/wxdragon.h` and the built wxWidgets headers.
       - Configure Cargo to link `libwxdragon.a` and the necessary wxWidgets libraries.
 
-### MacOS
-  Apart from the necessary build tools (CMake, Rust and the C++ compiler), the build requires no additional dependencies. wxDragon uses a hardcoded set of linker flags and bindgen include paths derived from `wx-config` for stability.
-
-#### Linux
-  wxDragon requires gtk+-3.0 which the build script finds via pkg-config. It also requires libclang to generate the bindings. This requires the user to install the development packages necessary to build wxWidgets. Which for debian-based distros:
-  ```bash
-  sudo apt-get install libclang-dev pkg-config libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev
-  ```
-
-### Windows
-#### GNU
-  If you're targeting the gnu toolchain, you will still need to install libclang which can be done using `pacman -S $MINGW_PACKAGE_PREFIX-clang`. This is necessary for generating the rust-bindgen bindings.
-
-#### MSVC
-  An additional build tool is required: Ninja!
-  This can be installed using winget (or any of the current windows package managers):
-  ```
-  winget install --id=Ninja-build.Ninja  -e
-  ```
-  libclang is also needed to generate the rust-bindgen bindings. This can be installed as instructed in the [rust-bindgen documentation](https://rust-lang.github.io/rust-bindgen/requirements.html), LLVM and libclang can also be installed through the Visual Studio Installer.
-  Also verify that you have a windows sdk installed through your Visual Studio Installer. 
+    #### MacOS
+      Apart from the necessary build tools (CMake, Rust and the C++ compiler), the build requires no additional dependencies. wxDragon uses a hardcoded set of linker flags and bindgen include paths derived from `wx-config` for stability.
+    
+    #### Linux
+      wxDragon requires gtk+-3.0 which the build script finds via pkg-config. It also requires libclang to generate the bindings. This requires the user to install the development packages necessary to build wxWidgets. Which for debian-based distros:
+      ```bash
+      sudo apt-get install libclang-dev pkg-config libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev
+      ```
+    
+    #### Windows
+    ##### GNU
+      If you're targeting the gnu toolchain, you will still need to install libclang which can be done using `pacman -S $MINGW_PACKAGE_PREFIX-clang`. This is necessary for generating the rust-bindgen bindings.
+    
+    ##### MSVC
+      An additional build tool is required: Ninja!
+      This can be installed using winget (or any of the current windows package managers):
+      ```
+      winget install --id=Ninja-build.Ninja  -e
+      ```
+      libclang is also needed to generate the rust-bindgen bindings. This can be installed as instructed in the [rust-bindgen documentation](https://rust-lang.github.io/rust-bindgen/requirements.html), LLVM and libclang can also be installed through the Visual Studio Installer.
+      Also verify that you have a windows sdk installed through your Visual Studio Installer. 
 
 ## Cross-Compilation (macOS to Windows)
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,25 @@ _(Note: The `const_extractor` path and the exact location of the workspace `Carg
       - Copy the appropriate pre-generated platform-specific constants file (e.g., `wx_msw_constants.rs`) from `rust/wxdragon-sys/src/generated_constants/` to `$OUT_DIR/wx_other_constants.rs`.
       - Generate Rust FFI bindings (`bindings.rs`) using `bindgen` against `rust/wxdragon-sys/cpp/include/wxdragon.h` and the built wxWidgets headers.
       - Configure Cargo to link `libwxdragon.a` and the necessary wxWidgets libraries.
-      - **For macOS:** Uses a hardcoded set of linker flags and bindgen include paths derived from `wx-config` for stability.
-      - **For Linux/Windows:** Current build script has placeholders; full support for these platforms (e.g., via `pkg-config` on Linux) is pending.
+
+### MacOS
+  Apart from the necessary build tools (CMake, Rust and the C++ compiler), the build requires no additional dependencies. wxDragon uses a hardcoded set of linker flags and bindgen include paths derived from `wx-config` for stability.
+
+#### Linux
+  wxDragon requires gtk+-3.0 which the build script finds via pkg-config. It also requires libclang to generate the bindings. This requires the user to install the development packages necessary to build wxWidgets. Which for debian-based distros:
+  ```bash
+  sudo apt-get install libclang-dev pkg-config libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev
+  ```
+
+### Windows
+#### GNU
+  If you're targeting the gnu toolchain, you will still need to install libclang which can be done using `pacman -S $MINGW_PACKAGE_PREFIX-clang`. This is necessary for generating the rust-bindgen bindings.
+
+#### MSVC
+  An additional build tool is required: Ninja!
+  libclang is also needed to generate the rust-bindgen bindings. This can be installed as instructed in the [rust-bindgen documentation](https://rust-lang.github.io/rust-bindgen/requirements.html). 
+  Also verify that you have a windows sdk installed through your Visual Studio Installer. 
+  
 
 ## Cross-Compilation (macOS to Windows)
 
@@ -235,7 +252,8 @@ To build the project on macOS targeting Windows (specifically `x86_64-pc-windows
     - Other Constants: Pre-generated platform-specific Rust files (e.g., `wx_msw_constants.rs`, `wx_gtk_constants.rs`) located in `rust/wxdragon-sys/src/generated_constants/`, copied to `$OUT_DIR/wx_other_constants.rs` by `build.rs`.
   - [x] `build.rs` supports incremental C++ builds.
   - [x] **macOS Build:** Uses hardcoded linker and bindgen flags for stability.
-  - [ ] **Linux/Windows Build:** Automated build support is under development.
+  - [x] **Linux Build:** Uses gtk+-3.0 which it finds via pkg-config. This requires additional installs of development packages and pkg-config on the system. Check the `Build Instructions` section.
+  - [x] **Windows Build:** Uses the current msw win32 backend. CMake currently builds wxWidgets for Release.
 - **`wxdragon-sys` Rust crate:**
   - [x] `bindgen` generates raw FFI bindings from `rust/wxdragon-sys/cpp/include/wxdragon.h`.
   - [x] `build.rs` correctly invokes CMake, downloads wxWidgets, copies pre-generated constants, and links libraries using a manual configuration for macOS.

--- a/README.md
+++ b/README.md
@@ -206,9 +206,12 @@ _(Note: The `const_extractor` path and the exact location of the workspace `Carg
 
 #### MSVC
   An additional build tool is required: Ninja!
-  libclang is also needed to generate the rust-bindgen bindings. This can be installed as instructed in the [rust-bindgen documentation](https://rust-lang.github.io/rust-bindgen/requirements.html). 
+  This can be installed using winget (or any of the current windows package managers):
+  ```
+  winget install --id=Ninja-build.Ninja  -e
+  ```
+  libclang is also needed to generate the rust-bindgen bindings. This can be installed as instructed in the [rust-bindgen documentation](https://rust-lang.github.io/rust-bindgen/requirements.html), LLVM and libclang can also be installed through the Visual Studio Installer.
   Also verify that you have a windows sdk installed through your Visual Studio Installer. 
-  
 
 ## Cross-Compilation (macOS to Windows)
 

--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -139,7 +139,16 @@ fn main() {
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 
     if target_os == "windows" && target_env == "gnu" {
-        // Potentially set MinGW toolchain for CMake if not automatically detected
+        
+    }
+
+    if target_os == "windows" {
+        cmake_config.define("CMAKE_BUILD_TYPE", "Release");
+        if target_env == "gnu" {
+            // Potentially set MinGW toolchain for CMake if not automatically detected
+        } else {
+            cmake_config.generator("Ninja");
+        }
     }
 
     let dst = cmake_config.build();
@@ -167,88 +176,96 @@ fn main() {
         wxwidgets_build_dir.join("lib").display()
     );
     // For Windows, wxWidgets libs might be in a subdirectory like gcc_x64_lib for MinGW
-    if target_os == "windows" && target_env == "gnu" {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            wxwidgets_build_dir.join("lib/gcc_x64_lib").display()
-        );
-
-        // --- Dynamically find MinGW GCC library paths ---
-        let gcc_path = "x86_64-w64-mingw32-gcc"; // Assume it's in PATH
-
-        // Find the path containing libgcc.a
-        let output_libgcc = Command::new(gcc_path)
-            .arg("-print-libgcc-file-name")
-            .output()
-            .expect("Failed to execute x86_64-w64-mingw32-gcc -print-libgcc-file-name");
-
-        if output_libgcc.status.success() {
-            let libgcc_path_str = String::from_utf8_lossy(&output_libgcc.stdout)
-                .trim()
-                .to_string();
-            if !libgcc_path_str.is_empty() {
-                let libgcc_path = Path::new(&libgcc_path_str);
-                if let Some(libgcc_dir) = libgcc_path.parent() {
-                    println!("cargo:rustc-link-search=native={}", libgcc_dir.display());
-                    println!(
-                        "info: Added GCC library search path (from libgcc): {}",
-                        libgcc_dir.display()
-                    );
-
-                    // Attempt to find the path containing libstdc++.a (often one level up, in `../<target>/lib`)
-                    if let Some(gcc_dir) = libgcc_dir.parent() {
-                        // e.g., .../gcc/x86_64-w64-mingw32/15.1.0 -> .../gcc/x86_64-w64-mingw32
-                        if let Some(toolchain_lib_dir) = gcc_dir.parent() {
-                            // e.g., .../gcc/x86_64-w64-mingw32 -> .../gcc
-                            if let Some(base_lib_dir) = toolchain_lib_dir.parent() {
-                                // e.g., .../gcc -> .../lib
-                                // Construct the expected path for libstdc++.a based on `find` result structure
-                                let libstdcpp_dir = base_lib_dir
-                                    .parent()
-                                    .unwrap()
-                                    .join("x86_64-w64-mingw32/lib"); // ../../x86_64-w64-mingw32/lib
-                                if libstdcpp_dir.exists() && libstdcpp_dir != libgcc_dir {
-                                    println!(
-                                        "cargo:rustc-link-search=native={}",
-                                        libstdcpp_dir.display()
-                                    );
-                                    println!(
-                                        "info: Added GCC library search path (for libstdc++): {}",
-                                        libstdcpp_dir.display()
-                                    );
-                                } else {
-                                    println!("info: Could not find or verify expected libstdc++ path relative to libgcc path: {}", libstdcpp_dir.display());
+    if target_os == "windows" {
+        if target_env == "gnu" {
+            println!(
+                "cargo:rustc-link-search=native={}",
+                wxwidgets_build_dir.join("lib/gcc_x64_lib").display()
+            );
+    
+            // --- Dynamically find MinGW GCC library paths ---
+            let gcc_path = "x86_64-w64-mingw32-gcc"; // Assume it's in PATH
+    
+            // Find the path containing libgcc.a
+            let output_libgcc = Command::new(gcc_path)
+                .arg("-print-libgcc-file-name")
+                .output()
+                .expect("Failed to execute x86_64-w64-mingw32-gcc -print-libgcc-file-name");
+    
+            if output_libgcc.status.success() {
+                let libgcc_path_str = String::from_utf8_lossy(&output_libgcc.stdout)
+                    .trim()
+                    .to_string();
+                if !libgcc_path_str.is_empty() {
+                    let libgcc_path = Path::new(&libgcc_path_str);
+                    if let Some(libgcc_dir) = libgcc_path.parent() {
+                        println!("cargo:rustc-link-search=native={}", libgcc_dir.display());
+                        println!(
+                            "info: Added GCC library search path (from libgcc): {}",
+                            libgcc_dir.display()
+                        );
+    
+                        // Attempt to find the path containing libstdc++.a (often one level up, in `../<target>/lib`)
+                        if let Some(gcc_dir) = libgcc_dir.parent() {
+                            // e.g., .../gcc/x86_64-w64-mingw32/15.1.0 -> .../gcc/x86_64-w64-mingw32
+                            if let Some(toolchain_lib_dir) = gcc_dir.parent() {
+                                // e.g., .../gcc/x86_64-w64-mingw32 -> .../gcc
+                                if let Some(base_lib_dir) = toolchain_lib_dir.parent() {
+                                    // e.g., .../gcc -> .../lib
+                                    // Construct the expected path for libstdc++.a based on `find` result structure
+                                    let libstdcpp_dir = base_lib_dir
+                                        .parent()
+                                        .unwrap()
+                                        .join("x86_64-w64-mingw32/lib"); // ../../x86_64-w64-mingw32/lib
+                                    if libstdcpp_dir.exists() && libstdcpp_dir != libgcc_dir {
+                                        println!(
+                                            "cargo:rustc-link-search=native={}",
+                                            libstdcpp_dir.display()
+                                        );
+                                        println!(
+                                            "info: Added GCC library search path (for libstdc++): {}",
+                                            libstdcpp_dir.display()
+                                        );
+                                    } else {
+                                        println!("info: Could not find or verify expected libstdc++ path relative to libgcc path: {}", libstdcpp_dir.display());
+                                    }
                                 }
                             }
                         }
+                    } else {
+                        println!(
+                            "cargo:warning=Could not get parent directory from libgcc path: {}",
+                            libgcc_path_str
+                        );
                     }
                 } else {
-                    println!(
-                        "cargo:warning=Could not get parent directory from libgcc path: {}",
-                        libgcc_path_str
-                    );
+                    println!("cargo:warning=Command -print-libgcc-file-name returned empty output.");
                 }
             } else {
-                println!("cargo:warning=Command -print-libgcc-file-name returned empty output.");
+                let stderr = String::from_utf8_lossy(&output_libgcc.stderr);
+                println!(
+                    "cargo:warning=Failed to run '{} -print-libgcc-file-name': {}",
+                    gcc_path, stderr
+                );
+                println!("cargo:warning=Static linking for stdc++/gcc might fail. Falling back to hoping they are in default paths.");
             }
+            // --- End dynamic path finding ---
+    
+            // REMOVED: Old hardcoded path
+            // println!("cargo:rustc-link-search=native=/opt/homebrew/Cellar/mingw-w64/12.0.0_3/toolchain-x86_64/x86_64-w64-mingw32/lib");
         } else {
-            let stderr = String::from_utf8_lossy(&output_libgcc.stderr);
             println!(
-                "cargo:warning=Failed to run '{} -print-libgcc-file-name': {}",
-                gcc_path, stderr
+                "cargo:rustc-link-search=native={}",
+                wxwidgets_build_dir.join("lib/vc_x64_lib").display()
             );
-            println!("cargo:warning=Static linking for stdc++/gcc might fail. Falling back to hoping they are in default paths.");
         }
-        // --- End dynamic path finding ---
-
-        // REMOVED: Old hardcoded path
-        // println!("cargo:rustc-link-search=native=/opt/homebrew/Cellar/mingw-w64/12.0.0_3/toolchain-x86_64/x86_64-w64-mingw32/lib");
     }
+
+    println!("cargo:rustc-link-lib=static=wxdragon");
 
     if target_os == "macos" {
         // macOS linking flags (assuming release build for wxWidgets library names here)
         // If macOS also has d suffix for debug, this section would need similar conditional logic
-        println!("cargo:rustc-link-lib=static=wxdragon");
         println!("cargo:rustc-link-lib=static=wx_osx_cocoau_core-3.2");
         println!("cargo:rustc-link-lib=static=wx_baseu-3.2");
         println!("cargo:rustc-link-lib=static=wx_baseu_xml-3.2");
@@ -285,33 +302,34 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=AVKit");
         println!("cargo:rustc-link-lib=framework=CoreMedia");
     } else if target_os == "windows" {
-        if is_debug {
-            println!("cargo:rustc-link-lib=static=wxdragond");
-            println!("info: Using DEBUG linking flags for Windows");
-            // wxWidgets debug libraries from user's ll output
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_aui");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_adv");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_core");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_gl");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_html");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_media");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_propgrid");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_stc");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_webview");
-            println!("cargo:rustc-link-lib=static=wxmsw32ud_xrc");
-            println!("cargo:rustc-link-lib=static=wxbase32ud_xml");
-            println!("cargo:rustc-link-lib=static=wxbase32ud");
-            println!("cargo:rustc-link-lib=static=wxpngd");
-            println!("cargo:rustc-link-lib=static=wxtiffd");
-            println!("cargo:rustc-link-lib=static=wxjpegd");
-            println!("cargo:rustc-link-lib=static=wxregexud");
-            println!("cargo:rustc-link-lib=static=wxzlibd");
-            println!("cargo:rustc-link-lib=static=wxscintillad");
-            println!("cargo:rustc-link-lib=static=wxexpatd");
-        } else {
-            println!("info: Using RELEASE linking flags for Windows (GNU) based on user-provided ll output.");
+        // if is_debug {
+        //     println!("info: Using DEBUG linking flags for Windows");
+        //     // wxWidgets debug libraries from user's ll output
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_aui");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_adv");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_core");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_gl");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_html");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_media");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_propgrid");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_stc");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_webview");
+        //     println!("cargo:rustc-link-lib=static=wxmsw32ud_xrc");
+        //     println!("cargo:rustc-link-lib=static=wxbase32ud_xml");
+        //     println!("cargo:rustc-link-lib=static=wxbase32ud");
+        //     println!("cargo:rustc-link-lib=static=wxpngd");
+        //     println!("cargo:rustc-link-lib=static=wxtiffd");
+        //     println!("cargo:rustc-link-lib=static=wxjpegd");
+        //     println!("cargo:rustc-link-lib=static=wxregexud");
+        //     println!("cargo:rustc-link-lib=static=wxzlibd");
+        //     println!("cargo:rustc-link-lib=static=wxscintillad");
+        //     println!("cargo:rustc-link-lib=static=wxexpatd");
+        //     if target_env == "msvc" {
+        //         println!("cargo:rustc-link-lib=stdc++");
+        //     }
+        // } else {
+            println!("info: Using RELEASE linking flags for Windows based on user-provided ll output.");
             // wxWidgets release libraries from user-provided ll output
-            println!("cargo:rustc-link-lib=static=wxdragon");
             println!("cargo:rustc-link-lib=static=wxmsw32u_aui");
             println!("cargo:rustc-link-lib=static=wxmsw32u_adv");
             println!("cargo:rustc-link-lib=static=wxmsw32u_core");
@@ -331,7 +349,7 @@ fn main() {
             println!("cargo:rustc-link-lib=static=wxzlib");
             println!("cargo:rustc-link-lib=static=wxscintilla");
             println!("cargo:rustc-link-lib=static=wxexpat");
-        }
+        // }
 
         // System libraries (same for debug and release)
         println!("cargo:rustc-link-lib=kernel32");
@@ -357,7 +375,6 @@ fn main() {
             println!("cargo:rustc-link-lib=stdc++");
         }
     } else {
-        println!("cargo:rustc-link-lib=static=wxdragon");
         println!("cargo:rustc-link-lib=xkbcommon");
         let lib = pkg_config::Config::new()
             .probe("gtk+-3.0")

--- a/rust/wxdragon-sys/cpp/src/app.cpp
+++ b/rust/wxdragon-sys/cpp/src/app.cpp
@@ -151,17 +151,17 @@ void wxd_free_int_array(int* ptr) {
     }
 }
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+// #ifdef __cplusplus
+// extern "C" {
+// #endif
 
-    // Dummy implementations to avoid linker errors in case Rust doesn't define them
-    #pragma weak process_rust_callbacks
-    void process_rust_callbacks() {
-        // This is a weak symbol that will be replaced by the actual Rust implementation
-        // If the Rust implementation is not available, this will be used instead
-    }
+//     // Dummy implementations to avoid linker errors in case Rust doesn't define them
+//     #pragma weak process_rust_callbacks
+//     void process_rust_callbacks() {
+//         // This is a weak symbol that will be replaced by the actual Rust implementation
+//         // If the Rust implementation is not available, this will be used instead
+//     }
 
-#ifdef __cplusplus
-}
-#endif
+// #ifdef __cplusplus
+// }
+// #endif


### PR DESCRIPTION
All green. 
Note that wxWidgets builds with certain flags with msvc when building for Debug. These are finicky to replicate with cmake-rs. So the current PR builds wxWidgets for Release on windows. Typically users shouldn’t need the debug build of wxwidgets. 
I’ve also updated the readme with instructions for linux and windows. 