### PR TITLE
isolate wxwidget headers from wrapper headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rust/wxdragon-sys/cpp/tools/const_extractor/const_extractor
 examples/cpp/minimal_cpp/minimal_cpp_notif_test.app/Contents
 examples/cpp/minimal_cpp/minimal_cpp_notif_test
 justfile
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wxdragon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 2.9.0",
  "lazy_static",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "wxdragon-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "wxdragon-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "bzip2",

--- a/rust/wxdragon-sys/cpp/include/array_string.h
+++ b/rust/wxdragon-sys/cpp/include/array_string.h
@@ -19,11 +19,6 @@ WXD_EXPORTED int wxd_ArrayString_GetString(wxd_ArrayString_t* array, int index, 
 WXD_EXPORTED bool wxd_ArrayString_Add(wxd_ArrayString_t* self, const char* str);
 WXD_EXPORTED void wxd_ArrayString_Clear(wxd_ArrayString_t* self);
 
-// Helper function to populate a wxd_ArrayString_t from a wxArrayString
-#ifdef __cplusplus
-WXD_EXPORTED void wxd_ArrayString_AssignFromWxArrayString(wxd_ArrayString_t* target, const wxArrayString& source);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
+++ b/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
@@ -3,12 +3,11 @@
 
 #include "../wxd_types.h"
 
-#ifndef __cplusplus
-// Provide a C-compatible typedef for wxEventType for bindgen, 
-// as it's used as a return type in C API functions parsed by bindgen.
-// The actual C++ definition comes from <wx/event.h> via wxd_types.h for C++ compilation.
-typedef int wxEventType;
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+typedef int wxEventType;
 
 // --- Event Handling & Data Access --- 
 WXD_EXPORTED void wxd_EvtHandler_Bind(
@@ -98,5 +97,9 @@ WXD_EXPORTED int32_t wxd_CheckListBoxEvent_GetSelection(wxd_Event_t* self);
 
 // Notebook specific event functions
 WXD_EXPORTED int32_t wxd_NotebookEvent_GetSelection(wxd_Event_t* self);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // WXD_EVENT_API_H 

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -1,20 +1,6 @@
 #ifndef WXD_TYPES_H
 #define WXD_TYPES_H
 
-#ifdef __cplusplus
-// Include essential wxWidgets headers for type definitions
-#include <wx/defs.h>      // For wxEventType, wxWindowID, etc.
-#include <wx/event.h>     // For wxEvent, wxCommandEvent, wxMouseEvent, wxKeyEvent etc.
-#include <wx/gdicmn.h>    // For wxPoint, wxSize, wxRect
-#include <wx/colour.h>    // For wxColour
-#include <wx/datetime.h>  // For wxDateTime
-#include <wx/variant.h>   // For wxVariant
-#include <wx/bmpbndl.h>   // For wxBitmapBundle
-#include <wx/rearrangectrl.h> // For wxRearrangeList
-// For DataView related types
-#include <wx/dataview.h>  // For wxDataViewItem, wxDataViewModel, etc.
-#endif
-
 // Use standard C types
 #include <stdbool.h> 
 #include <stdint.h> // For integer types if needed
@@ -435,11 +421,7 @@ typedef struct wxd_TreeItemId_Opaque_ForBindgen wxd_TreeItemId_t; // Define as o
 
 // --- Opaque and FFI Struct Definitions ---
 // Moved from wxd_event_api.h to ensure it's defined before use in event.cpp
-#ifdef __cplusplus
-struct wxd_Event_t { wxEvent* event; };
-#else
 typedef struct wxd_Event_t wxd_Event_t;
-#endif
 
 typedef struct wxd_App_t wxd_App_t;
 typedef struct wxd_Window_t wxd_Window_t;

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -36,6 +36,8 @@
 #include <wx/utils.h>
 #include <wx/rearrangectrl.h> // ADDED: For wxEVT_REARRANGE_LIST
 
+struct wxd_Event_t { wxEvent* event; };
+
 // --- Internal C++ Structures/Classes (Not exposed in C API) ---
 
 // Define a hash function for std::pair<int, int>

--- a/rust/wxdragon-sys/cpp/src/file_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/file_dialog.cpp
@@ -4,6 +4,8 @@
 #include "../include/wxdragon.h"
 #include "wxd_utils.h" // For WXD_STR_TO_WX_STRING_UTF8_NULL_OK and GET_WX_STRING_RESULT
 
+extern void wxd_ArrayString_AssignFromWxArrayString(wxd_ArrayString_t* target, const wxArrayString& source);
+
 // --- wxFileDialog ---
 
 WXD_EXPORTED wxd_FileDialog_t* wxd_FileDialog_Create(


### PR DESCRIPTION
Hi @AllenDang 

This PR addresses the build failure in docs.rs.
It basically generates the bindings then returns, without having to download and build wxwidgets. This is done via isolating wxwidget headers from wxdragon headers. 
I can't test my theory, you would have to publish a new release and check whether docs.rs builds correctly or not.

Note the downside of this isolation is that you would have to typedef (or use opaque types) a bit more for the wxdragon headers. The advantage is that it should build on docs.rs, in addition to potentially speeding build times since rust-bindgen no longer has to go through wxwidget headers.