### PR TITLE
about event.can_veto() in taskbar_demo

### DIFF
--- a/examples/rust/gallery/src/main.rs
+++ b/examples/rust/gallery/src/main.rs
@@ -252,7 +252,7 @@ fn main() {
         frame.on_menu(move |event| match event.get_id() {
             id if id == ID_EXIT => {
                 println!("Menu/Toolbar: Exit clicked!");
-                frame_clone_for_menu.close();
+                frame_clone_for_menu.close(true);
             }
             id if id == ID_ABOUT => {
                 println!("Menu: About clicked!");

--- a/examples/rust/simple_xrc_test/src/main.rs
+++ b/examples/rust/simple_xrc_test/src/main.rs
@@ -151,7 +151,7 @@ fn main() {
         let menu_exit_clone = menu_exit.clone();
         menu_exit_clone.on_click(move |_event| {
             println!("Exit menu item clicked!");
-            frame_clone_for_exit.close();
+            frame_clone_for_exit.close(true);
         });
 
         let statusbar_for_about = statusbar.clone();

--- a/examples/rust/taskbar_demo/Cargo.toml
+++ b/examples/rust/taskbar_demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "taskbar_demo"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 wxdragon = { path = "../../../rust/wxdragon" }

--- a/examples/rust/taskbar_demo/src/main.rs
+++ b/examples/rust/taskbar_demo/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
                         status.set_label("Menu: Exit clicked - closing application...");
 
                         // Close the frame, which will trigger the on_close event
-                        frame.close();
+                        frame.close(true);
                     }
                     _ => {
                         println!("Unknown menu item clicked: {menu_id}");

--- a/examples/rust/taskbar_demo/src/main.rs
+++ b/examples/rust/taskbar_demo/src/main.rs
@@ -117,12 +117,14 @@ fn main() {
         frame.show(true);
         frame.centre();
 
-        frame.on_close({
-            let frame = frame.clone();
-            move |evt| {
+        let frame_clone = frame.clone();
+        frame.on_close(move |evt| {
+            if let wxdragon::WindowEventData::General(event) = &evt
+                && event.can_veto()
+            {
                 use MessageDialogStyle::{Cancel, IconInformation, YesNo};
                 let res = MessageDialog::builder(
-                    &frame,
+                    &frame_clone,
                     "Are you sure you want to close the application?",
                     "Confirm Close",
                 )
@@ -132,21 +134,14 @@ fn main() {
 
                 if res != wxdragon::ID_YES {
                     // User cancelled (clicked No or Cancel), prevent the close
-                    if let wxdragon::WindowEventData::General(event) = &evt {
-                        if event.can_veto() {
-                            event.veto();
-                        }
-                    }
+                    event.veto();
                 }
             }
         });
 
-        frame.on_destroy({
-            let taskbar = taskbar.clone();
-            move |_evt| {
-                taskbar.destroy(); // Clean up the TaskBarIcon
-                println!("Application on_destroy.");
-            }
+        frame.on_destroy(move |_evt| {
+            taskbar.destroy(); // Clean up the TaskBarIcon
+            println!("Application on_destroy.");
         });
     });
 }

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -245,10 +245,10 @@ impl Frame {
     }
 
     /// Closes the frame.
-    pub fn close(&self) {
+    pub fn close(&self, force: bool) {
         unsafe {
             // false = don't force close, allow events like EVT_CLOSE_WINDOW
-            ffi::wxd_Frame_Close(self.window.as_ptr() as *mut ffi::wxd_Frame_t, false);
+            ffi::wxd_Frame_Close(self.window.as_ptr() as *mut ffi::wxd_Frame_t, force);
         }
     }
 


### PR DESCRIPTION
if `event.can_veto()` is false, the message dialog shouldn't display at all.