### PR TITLE
Add wxWindow::GetHandle() to the API and allow access to internal window from a Frame

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -112,4 +112,8 @@ WXD_EXPORTED int64_t wxd_Window_GetLastPosition(wxd_Window_t* window);
 // Widget type identification using wxWidgets' built-in RTTI
 WXD_EXPORTED const char* wxd_Window_GetClassName(wxd_Window_t* window);
 
+// --- Platform-specific Functions ---
+/// Gets the native handle of the window (platform-specific)
+WXD_EXPORTED void* wxd_Window_GetHandle(wxd_Window_t* window);
+
 #endif // WXD_WINDOW_BASE_H 

--- a/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
+++ b/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
@@ -29,6 +29,7 @@ WXD_EXPORTED int wxd_CommandEvent_GetString(wxd_Event_t* event, char* buffer, in
 WXD_EXPORTED bool wxd_CommandEvent_IsChecked(wxd_Event_t* event);
 WXD_EXPORTED wxd_Point wxd_MouseEvent_GetPosition(wxd_Event_t* event);
 WXD_EXPORTED int wxd_KeyEvent_GetKeyCode(wxd_Event_t* event);
+WXD_EXPORTED int wxd_KeyEvent_GetUnicodeKey(wxd_Event_t* event);
 WXD_EXPORTED int wxd_CommandEvent_GetInt(wxd_Event_t* event);
 
 WXD_EXPORTED int wxd_ScrollEvent_GetPosition(wxd_Event_t* event);

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -609,6 +609,15 @@ WXD_EXPORTED int wxd_KeyEvent_GetKeyCode(wxd_Event_t* event) {
     return keyEvent->GetKeyCode();
 }
 
+WXD_EXPORTED int wxd_KeyEvent_GetUnicodeKey(wxd_Event_t* event) {
+    if (!event) return 0; 
+    wxEvent* baseEvent = static_cast<wxEvent*>(static_cast<void*>(event)); // Cast via void*
+    wxKeyEvent* keyEvent = dynamic_cast<wxKeyEvent*>(baseEvent);
+    if (!keyEvent) return 0; // Not a key event or derived
+
+    return keyEvent->GetUnicodeKey();
+}
+
 // ADDED: Implementation for wxd_CommandEvent_GetInt
 WXD_EXPORTED int wxd_CommandEvent_GetInt(wxd_Event_t* event) {
     if (!event) return 0;

--- a/rust/wxdragon-sys/cpp/src/window.cpp
+++ b/rust/wxdragon-sys/cpp/src/window.cpp
@@ -764,6 +764,15 @@ WXD_EXPORTED int64_t wxd_Window_GetLastPosition(wxd_Window_t* window) {
     return 0;
 }
 
+// --- Platform-specific Functions ---
+
+WXD_EXPORTED void* wxd_Window_GetHandle(wxd_Window_t* self) {
+    if (!self) {
+        return nullptr;
+    }
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(self);
+    return reinterpret_cast<void*>(wx_window->GetHandle());
+}
 
 
 // Get wxWidgets class name using built-in RTTI

--- a/rust/wxdragon/src/event/event_data.rs
+++ b/rust/wxdragon/src/event/event_data.rs
@@ -82,6 +82,10 @@ impl KeyEventData {
         self.event.get_key_code()
     }
 
+    pub fn get_unicode_key(&self) -> Option<i32> {
+        self.event.get_unicode_key()
+    }
+
     pub fn skip(&self, skip: bool) {
         self.event.skip(skip);
     }

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -751,7 +751,6 @@ impl Event {
         }
     }
 
-
     /// Gets the integer value associated with a command event.
     pub fn get_int(&self) -> Option<i32> {
         if self.0.is_null() {

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -738,6 +738,20 @@ impl Event {
         }
     }
 
+    /// Gets the key unicode value associated with a key event.
+    pub fn get_unicode_key(&self) -> Option<i32> {
+        if self.0.is_null() {
+            return None;
+        }
+        let key_code = unsafe { ffi::wxd_KeyEvent_GetUnicodeKey(self.0) };
+        if key_code == 0 {
+            None
+        } else {
+            Some(key_code)
+        }
+    }
+
+
     /// Gets the integer value associated with a command event.
     pub fn get_int(&self) -> Option<i32> {
         if self.0.is_null() {

--- a/rust/wxdragon/src/event/window_events.rs
+++ b/rust/wxdragon/src/event/window_events.rs
@@ -196,6 +196,11 @@ impl KeyboardEvent {
     pub fn get_key_code(&self) -> Option<i32> {
         self.event.get_key_code()
     }
+
+    pub fn get_unicode_key(&self) -> Option<i32> {
+        self.event.get_unicode_key()
+    }
+
 }
 
 /// Window size events

--- a/rust/wxdragon/src/event/window_events.rs
+++ b/rust/wxdragon/src/event/window_events.rs
@@ -200,7 +200,6 @@ impl KeyboardEvent {
     pub fn get_unicode_key(&self) -> Option<i32> {
         self.event.get_unicode_key()
     }
-
 }
 
 /// Window size events

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -190,7 +190,7 @@ impl Frame {
 
     /// Return internal window
     pub fn get_window(&self) -> Window {
-        return self.window;
+        self.window
     }
 
     /// Sets the frame's title.

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -188,6 +188,11 @@ impl Frame {
         FrameBuilder::default()
     }
 
+    /// Return internal window
+    pub fn get_window(&self) -> Window {
+        return self.window;
+    }
+
     /// Sets the frame's title.
     pub fn set_title(&self, title: &str) {
         let title_c = CString::new(title).expect("CString::new failed");

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -1358,7 +1358,7 @@ pub trait WxWidget {
     /// # Safety
     /// The returned pointer should not be used to modify the window and may
     /// only be valid for the lifetime of this `Window` instance.
-    /// 
+    ///
     fn get_handle(&self) -> *mut std::ffi::c_void {
         let handle = self.handle_ptr();
         if handle.is_null() {
@@ -1368,7 +1368,6 @@ pub trait WxWidget {
         let handle_ptr = unsafe { ffi::wxd_Window_GetHandle(handle) };
         return handle_ptr;
     }
-
 }
 
 /// Trait for widgets that can be cast from a Window using class name matching

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -1349,6 +1349,30 @@ pub trait WxWidget {
 
     // Other common methods (SetSize, GetSize, etc.) can be added here
     // if corresponding wxd_Window_* functions are added to the C API.
+
+    /// Gets the native handle of the window (platform-specific).
+    ///
+    /// # Returns
+    /// A raw pointer to the native window, or null if not available
+    ///
+    /// # Safety
+    /// The returned pointer should not be used to modify the window and may
+    /// only be valid for the lifetime of this `Window` instance.
+    /// 
+    fn get_handle(&self) -> *mut std::ffi::c_void {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        let handle_ptr = unsafe { ffi::wxd_Window_GetHandle(handle) };
+        return handle_ptr;
+    }
+
+    // pub unsafe fn get_handle(&self) -> *mut std::ffi::c_void {
+    //     ffi::wxd_Window_GetHandle(self)
+    // }
+
 }
 
 /// Trait for widgets that can be cast from a Window using class name matching

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -1364,9 +1364,7 @@ pub trait WxWidget {
         if handle.is_null() {
             return std::ptr::null_mut();
         }
-
-        let handle_ptr = unsafe { ffi::wxd_Window_GetHandle(handle) };
-        return handle_ptr;
+        unsafe { ffi::wxd_Window_GetHandle(handle) }
     }
 }
 

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -1369,10 +1369,6 @@ pub trait WxWidget {
         return handle_ptr;
     }
 
-    // pub unsafe fn get_handle(&self) -> *mut std::ffi::c_void {
-    //     ffi::wxd_Window_GetHandle(self)
-    // }
-
 }
 
 /// Trait for widgets that can be cast from a Window using class name matching


### PR DESCRIPTION
Hi, just a small proposal from my side to your excellent code! I finally have found a very good way to build native (macos) gui app in rust. I need to access the NSView pointer in my app, the reason why I suggest this PR. I haven't done heavy testing, but at least for me it works! No issue, if you think this addition is unnecessary.