### PR TITLE
build: support static CRT linking for windows targets

### DIFF
--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -288,12 +288,10 @@ fn build_wxdragon_wrapper(
 
             let rt_lib = if crt_static {
                 if is_debug { "MultiThreadedDebug" } else { "MultiThreaded" }
+            } else if is_debug {
+                "MultiThreadedDebugDLL"
             } else {
-                if is_debug {
-                    "MultiThreadedDebugDLL"
-                } else {
-                    "MultiThreadedDLL"
-                }
+                "MultiThreadedDLL"
             };
 
             let build_type = if is_debug { "Debug" } else { "RelWithDebInfo" };


### PR DESCRIPTION
Detect the crt-static target feature and configure the MSVC runtime library
accordingly. This ensures wxWidgets and the wrapper are built with the
same CRT linkage as the Rust code when building a fully static binary.

