### PR TITLE
Fixed get_value and friends giving you null bytes in the middle of the stream.

### DIFF
--- a/examples/rust/simple/src/main.rs
+++ b/examples/rust/simple/src/main.rs
@@ -51,4 +51,3 @@ fn main() {
         // Frame is automatically managed after show()
     });
 }
-

--- a/rust/wxdragon/src/widgets/richtextctrl.rs
+++ b/rust/wxdragon/src/widgets/richtextctrl.rs
@@ -748,4 +748,3 @@ impl crate::window::FromWindowWithClassName for RichTextCtrl {
         }
     }
 }
-

--- a/rust/wxdragon/src/widgets/textctrl.rs
+++ b/rust/wxdragon/src/widgets/textctrl.rs
@@ -474,4 +474,3 @@ impl crate::window::FromWindowWithClassName for TextCtrl {
         }
     }
 }
-


### PR DESCRIPTION
Noticed a really weird bug in my app where get_value was giving me a string with embedded nulls in it. Did a bit of digging, and you hardcoded a 1024 buffer for the return value, and then never expanded it. Fixed this with a helper function that now seems to work with any length of text, the test app does 1000 just fine.