### PR TITLE
Add extensive text formatting and colour dialog capabilities

### DIFF
--- a/rust/wxdragon-sys/cpp/include/dialogs/wxd_dialogs.h
+++ b/rust/wxdragon-sys/cpp/include/dialogs/wxd_dialogs.h
@@ -108,6 +108,18 @@ WXD_EXPORTED wxd_Colour_t
 wxd_ColourData_GetColour(wxd_ColourData_t* self);
 
 WXD_EXPORTED void
+wxd_ColourData_SetChooseFull(wxd_ColourData_t* self, bool flag);
+
+WXD_EXPORTED bool
+wxd_ColourData_GetChooseFull(wxd_ColourData_t* self);
+
+WXD_EXPORTED void
+wxd_ColourData_SetCustomColour(wxd_ColourData_t* self, int i, wxd_Colour_t colour);
+
+WXD_EXPORTED wxd_Colour_t
+wxd_ColourData_GetCustomColour(wxd_ColourData_t* self, int i);
+
+WXD_EXPORTED void
 wxd_ColourData_Destroy(wxd_ColourData_t* self);
 
 WXD_EXPORTED wxd_ColourDialog_t*

--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
@@ -15,6 +15,18 @@ WXD_EXPORTED void
 wxd_TextCtrl_AppendText(wxd_TextCtrl_t* textCtrl, const char* text);
 WXD_EXPORTED void
 wxd_TextCtrl_Clear(wxd_TextCtrl_t* textCtrl);
+WXD_EXPORTED void
+wxd_TextCtrl_WriteText(wxd_TextCtrl_t* textCtrl, const char* text);
+WXD_EXPORTED void
+wxd_TextCtrl_ChangeValue(wxd_TextCtrl_t* textCtrl, const char* value);
+WXD_EXPORTED void
+wxd_TextCtrl_Remove(wxd_TextCtrl_t* textCtrl, wxd_Long_t from, wxd_Long_t to);
+WXD_EXPORTED void
+wxd_TextCtrl_Replace(wxd_TextCtrl_t* textCtrl, wxd_Long_t from, wxd_Long_t to, const char* value);
+WXD_EXPORTED int
+wxd_TextCtrl_GetNumberOfLines(wxd_TextCtrl_t* textCtrl);
+WXD_EXPORTED int
+wxd_TextCtrl_GetLineText(wxd_TextCtrl_t* textCtrl, wxd_Long_t lineNo, char* buffer, int buffer_len);
 WXD_EXPORTED bool
 wxd_TextCtrl_IsModified(wxd_TextCtrl_t* textCtrl);
 WXD_EXPORTED void
@@ -48,5 +60,61 @@ wxd_TextCtrl_GetStringSelection(wxd_TextCtrl_t* textCtrl, char* buffer, int buff
 
 WXD_EXPORTED void
 wxd_TextCtrl_SetInsertionPointEnd(wxd_TextCtrl_t* textCtrl);
+
+// --- TextAttr Functions ---
+WXD_EXPORTED wxd_TextAttr_t*
+wxd_TextAttr_Create();
+
+WXD_EXPORTED void
+wxd_TextAttr_Delete(wxd_TextAttr_t* attr);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetTextColour(wxd_TextAttr_t* attr, wxd_Colour_t colText);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetBackgroundColour(wxd_TextAttr_t* attr, wxd_Colour_t colBack);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetFont(wxd_TextAttr_t* attr, const wxd_Font_t* font);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetAlignment(wxd_TextAttr_t* attr, int alignment);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetLeftIndent(wxd_TextAttr_t* attr, int indent, int subIndent);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetRightIndent(wxd_TextAttr_t* attr, int indent);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetLineSpacing(wxd_TextAttr_t* attr, int spacing);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetParagraphSpacingAfter(wxd_TextAttr_t* attr, int spacing);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetParagraphSpacingBefore(wxd_TextAttr_t* attr, int spacing);
+
+WXD_EXPORTED void
+wxd_TextAttr_SetBulletStyle(wxd_TextAttr_t* attr, int style);
+
+// --- TextCtrl Style Functions ---
+WXD_EXPORTED void
+wxd_TextCtrl_SetStyle(wxd_TextCtrl_t* textCtrl, wxd_Long_t start, wxd_Long_t end, const wxd_TextAttr_t* style);
+
+WXD_EXPORTED wxd_TextAttr_t*
+wxd_TextCtrl_GetDefaultStyle(wxd_TextCtrl_t* textCtrl);
+
+WXD_EXPORTED void
+wxd_TextCtrl_SetDefaultStyle(wxd_TextCtrl_t* textCtrl, const wxd_TextAttr_t* style);
+
+WXD_EXPORTED bool
+wxd_TextCtrl_PositionToXY(wxd_TextCtrl_t* textCtrl, wxd_Long_t pos, wxd_Long_t* x, wxd_Long_t* y);
+
+WXD_EXPORTED wxd_Long_t
+wxd_TextCtrl_XYToPosition(wxd_TextCtrl_t* textCtrl, wxd_Long_t x, wxd_Long_t y);
+
+WXD_EXPORTED int
+wxd_TextCtrl_GetLineLength(wxd_TextCtrl_t* textCtrl, wxd_Long_t lineNo);
 
 #endif // WXD_TEXTCTRL_H

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -423,6 +423,7 @@ typedef struct wxd_ColourData wxd_ColourData_t;
 typedef struct wxd_ColourDialog wxd_ColourDialog_t;
 typedef struct wxd_FontData wxd_FontData_t;
 typedef struct wxd_Font_t wxd_Font_t;
+typedef struct wxd_TextAttr_t wxd_TextAttr_t;
 typedef struct wxd_FontDialog wxd_FontDialog_t;
 typedef struct wxd_TextEntryDialog wxd_TextEntryDialog_t;
 typedef struct wxd_ProgressDialog wxd_ProgressDialog_t;

--- a/rust/wxdragon-sys/cpp/src/colourdialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/colourdialog.cpp
@@ -55,6 +55,37 @@ wxd_ColourData_GetColour(wxd_ColourData_t* self)
     return to_wxd(data->GetColour());
 }
 
+WXD_EXPORTED void
+wxd_ColourData_SetChooseFull(wxd_ColourData_t* self, bool flag)
+{
+    wxColourData* data = reinterpret_cast<wxColourData*>(self);
+    if (data) data->SetChooseFull(flag);
+}
+
+WXD_EXPORTED bool
+wxd_ColourData_GetChooseFull(wxd_ColourData_t* self)
+{
+    wxColourData* data = reinterpret_cast<wxColourData*>(self);
+    if (!data) return false;
+    return data->GetChooseFull();
+}
+
+WXD_EXPORTED void
+wxd_ColourData_SetCustomColour(wxd_ColourData_t* self, int i, wxd_Colour_t colour)
+{
+    wxColourData* data = reinterpret_cast<wxColourData*>(self);
+    if (data) data->SetCustomColour(i, to_wx(colour));
+}
+
+WXD_EXPORTED wxd_Colour_t
+wxd_ColourData_GetCustomColour(wxd_ColourData_t* self, int i)
+{
+    wxColourData* data = reinterpret_cast<wxColourData*>(self);
+    if (!data) return wxd_Colour_t{0, 0, 0, 0};
+    wxColour c = data->GetCustomColour(i);
+    return to_wxd(c);
+}
+
 void
 wxd_ColourData_Destroy(wxd_ColourData_t* self)
 {

--- a/rust/wxdragon-sys/cpp/src/textctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/textctrl.cpp
@@ -62,6 +62,60 @@ wxd_TextCtrl_Clear(wxd_TextCtrl_t* textCtrl)
     }
 }
 
+WXD_EXPORTED void
+wxd_TextCtrl_WriteText(wxd_TextCtrl_t* textCtrl, const char* text)
+{
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    if (ctrl && text) {
+        ctrl->WriteText(wxString::FromUTF8(text));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextCtrl_ChangeValue(wxd_TextCtrl_t* textCtrl, const char* value)
+{
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    if (ctrl) {
+        ctrl->ChangeValue(wxString::FromUTF8(value ? value : ""));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextCtrl_Remove(wxd_TextCtrl_t* textCtrl, wxd_Long_t from, wxd_Long_t to)
+{
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    if (ctrl) {
+        ctrl->Remove(from, to);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextCtrl_Replace(wxd_TextCtrl_t* textCtrl, wxd_Long_t from, wxd_Long_t to, const char* value)
+{
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    if (ctrl && value) {
+        ctrl->Replace(from, to, wxString::FromUTF8(value));
+    }
+}
+
+WXD_EXPORTED int
+wxd_TextCtrl_GetNumberOfLines(wxd_TextCtrl_t* textCtrl)
+{
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    if (!ctrl) return 0;
+    return ctrl->GetNumberOfLines();
+}
+
+WXD_EXPORTED int
+wxd_TextCtrl_GetLineText(wxd_TextCtrl_t* textCtrl, wxd_Long_t lineNo, char* buffer, int buffer_len)
+{
+    if (!textCtrl || !buffer || buffer_len <= 0)
+        return -1;
+    wxTextCtrl* ctrl = (wxTextCtrl*)textCtrl;
+    wxString text = ctrl->GetLineText(lineNo);
+    return wxd_cpp_utils::copy_wxstring_to_buffer(text, buffer, (size_t)buffer_len);
+}
+
 // Check if the wxTextCtrl has been modified
 WXD_EXPORTED bool
 wxd_TextCtrl_IsModified(wxd_TextCtrl_t* textCtrl)
@@ -210,6 +264,159 @@ wxd_TextCtrl_SetInsertionPointEnd(wxd_TextCtrl_t* textCtrl)
     if (ctrl) {
         ctrl->SetInsertionPointEnd();
     }
+}
+
+// Helper to convert wxd_Colour_t to wxColour
+static inline wxColour
+to_wx(wxd_Colour_t c_col)
+{
+    return wxColour(c_col.r, c_col.g, c_col.b, c_col.a);
+}
+
+WXD_EXPORTED wxd_TextAttr_t*
+wxd_TextAttr_Create()
+{
+    return reinterpret_cast<wxd_TextAttr_t*>(new wxTextAttr());
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_Delete(wxd_TextAttr_t* attr)
+{
+    delete reinterpret_cast<wxTextAttr*>(attr);
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetTextColour(wxd_TextAttr_t* attr, wxd_Colour_t colText)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetTextColour(to_wx(colText));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetBackgroundColour(wxd_TextAttr_t* attr, wxd_Colour_t colBack)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetBackgroundColour(to_wx(colBack));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetFont(wxd_TextAttr_t* attr, const wxd_Font_t* font)
+{
+    if (attr && font) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetFont(*reinterpret_cast<const wxFont*>(font));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetAlignment(wxd_TextAttr_t* attr, int alignment)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetAlignment(static_cast<wxTextAttrAlignment>(alignment));
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetLeftIndent(wxd_TextAttr_t* attr, int indent, int subIndent)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetLeftIndent(indent, subIndent);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetRightIndent(wxd_TextAttr_t* attr, int indent)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetRightIndent(indent);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetLineSpacing(wxd_TextAttr_t* attr, int spacing)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetLineSpacing(spacing);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetParagraphSpacingAfter(wxd_TextAttr_t* attr, int spacing)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetParagraphSpacingAfter(spacing);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetParagraphSpacingBefore(wxd_TextAttr_t* attr, int spacing)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetParagraphSpacingBefore(spacing);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextAttr_SetBulletStyle(wxd_TextAttr_t* attr, int style)
+{
+    if (attr) {
+        reinterpret_cast<wxTextAttr*>(attr)->SetBulletStyle(style);
+    }
+}
+
+WXD_EXPORTED void
+wxd_TextCtrl_SetStyle(wxd_TextCtrl_t* textCtrl, wxd_Long_t start, wxd_Long_t end, const wxd_TextAttr_t* style)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (ctrl && style) {
+        ctrl->SetStyle(start, end, *reinterpret_cast<const wxTextAttr*>(style));
+    }
+}
+
+WXD_EXPORTED wxd_TextAttr_t*
+wxd_TextCtrl_GetDefaultStyle(wxd_TextCtrl_t* textCtrl)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (!ctrl) return nullptr;
+    return reinterpret_cast<wxd_TextAttr_t*>(new wxTextAttr(ctrl->GetDefaultStyle()));
+}
+
+WXD_EXPORTED void
+wxd_TextCtrl_SetDefaultStyle(wxd_TextCtrl_t* textCtrl, const wxd_TextAttr_t* style)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (ctrl && style) {
+        ctrl->SetDefaultStyle(*reinterpret_cast<const wxTextAttr*>(style));
+    }
+}
+
+WXD_EXPORTED bool
+wxd_TextCtrl_PositionToXY(wxd_TextCtrl_t* textCtrl, wxd_Long_t pos, wxd_Long_t* x, wxd_Long_t* y)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (!ctrl || !x || !y) return false;
+    long lx, ly;
+    bool res = ctrl->PositionToXY(static_cast<long>(pos), &lx, &ly);
+    *x = static_cast<wxd_Long_t>(lx);
+    *y = static_cast<wxd_Long_t>(ly);
+    return res;
+}
+
+WXD_EXPORTED wxd_Long_t
+wxd_TextCtrl_XYToPosition(wxd_TextCtrl_t* textCtrl, wxd_Long_t x, wxd_Long_t y)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (!ctrl) return 0;
+    return static_cast<wxd_Long_t>(ctrl->XYToPosition(static_cast<long>(x), static_cast<long>(y)));
+}
+
+WXD_EXPORTED int
+wxd_TextCtrl_GetLineLength(wxd_TextCtrl_t* textCtrl, wxd_Long_t lineNo)
+{
+    wxTextCtrl* ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    if (!ctrl) return 0;
+    return ctrl->GetLineLength(static_cast<long>(lineNo));
 }
 
 } // extern "C"

--- a/rust/wxdragon/src/dialogs/colour_dialog.rs
+++ b/rust/wxdragon/src/dialogs/colour_dialog.rs
@@ -15,6 +15,8 @@ pub struct ColourDialogBuilder<'a, W: WxWidget> {
     parent: &'a W,
     title: String,
     initial_colour: Option<Colour>,
+    choose_full: bool,
+    custom_colours: std::collections::HashMap<i32, Colour>,
 }
 
 impl ColourDialog {
@@ -24,6 +26,8 @@ impl ColourDialog {
             parent,
             title: "Choose a colour".to_string(),
             initial_colour: None,
+            choose_full: false,
+            custom_colours: std::collections::HashMap::new(),
         }
     }
 
@@ -75,16 +79,40 @@ impl<'a, W: WxWidget> ColourDialogBuilder<'a, W> {
         self
     }
 
+    /// Under Windows, determines whether the Windows colour dialog will display
+    /// the full dialog with custom colour selection controls when it is first shown.
+    pub fn with_choose_full(mut self, choose_full: bool) -> Self {
+        self.choose_full = choose_full;
+        self
+    }
+
+    /// Sets custom colours (index from 0 to 15) to be displayed in the
+    /// bottom row of custom colour swatches.
+    pub fn with_custom_colour(mut self, index: i32, colour: Colour) -> Self {
+        self.custom_colours.insert(index, colour);
+        self
+    }
+
     /// Build the ColourDialog
     pub fn build(self) -> ColourDialog {
         let c_title = CString::new(self.title).expect("CString::new failed for title");
 
-        // Create a temporary ColourData if we have an initial colour
-        let colour_data_ptr = if let Some(colour) = self.initial_colour {
+        // Create a temporary ColourData if we have an initial colour, choose_full flag or custom colours
+        let has_custom_data = self.initial_colour.is_some() || self.choose_full || !self.custom_colours.is_empty();
+
+        let colour_data_ptr = if has_custom_data {
             let data_ptr = unsafe { ffi::wxd_ColourData_Create() };
             if !data_ptr.is_null() {
-                unsafe {
-                    ffi::wxd_ColourData_SetColour(data_ptr, colour.into());
+                if let Some(colour) = self.initial_colour {
+                    unsafe { ffi::wxd_ColourData_SetColour(data_ptr, colour.into()) };
+                }
+
+                if self.choose_full {
+                    unsafe { ffi::wxd_ColourData_SetChooseFull(data_ptr, true) };
+                }
+
+                for (index, colour) in self.custom_colours {
+                    unsafe { ffi::wxd_ColourData_SetCustomColour(data_ptr, index, colour.into()) };
                 }
             }
             data_ptr

--- a/rust/wxdragon/src/widgets/textctrl.rs
+++ b/rust/wxdragon/src/widgets/textctrl.rs
@@ -222,6 +222,102 @@ impl TextCtrl {
         }
     }
 
+    /// Writes text into the control at the current insertion point.
+    /// No-op if the control has been destroyed.
+    pub fn write_text(&self, text: &str) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        let c_text = CString::new(text).unwrap_or_default();
+        unsafe { ffi::wxd_TextCtrl_WriteText(ptr, c_text.as_ptr()) };
+    }
+
+    /// Sets the value of the control without generating a TextChanged event.
+    /// No-op if the control has been destroyed.
+    pub fn change_value(&self, value: &str) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        let c_value = CString::new(value).unwrap_or_default();
+        unsafe { ffi::wxd_TextCtrl_ChangeValue(ptr, c_value.as_ptr()) };
+    }
+
+    /// Removes the text in the given range.
+    /// No-op if the control has been destroyed.
+    pub fn remove(&self, from: i64, to: i64) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_TextCtrl_Remove(ptr, from, to) };
+    }
+
+    /// Replaces the text in the given range with the new value.
+    /// No-op if the control has been destroyed.
+    pub fn replace(&self, from: i64, to: i64, value: &str) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        let c_value = CString::new(value).unwrap_or_default();
+        unsafe { ffi::wxd_TextCtrl_Replace(ptr, from, to, c_value.as_ptr()) };
+    }
+
+    /// Converts given text position to client coordinates in pixels.
+    /// Returns (x, y) if successful, or None if the position is invalid or the control is destroyed.
+    pub fn position_to_xy(&self, pos: i64) -> Option<(i64, i64)> {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return None;
+        }
+        let mut x: i64 = 0;
+        let mut y: i64 = 0;
+        let result = unsafe { ffi::wxd_TextCtrl_PositionToXY(ptr, pos, &mut x, &mut y) };
+        if result { Some((x, y)) } else { None }
+    }
+
+    /// Converts given client coordinates in pixels to text position.
+    /// Returns 0 if the coordinates are invalid or the control is destroyed.
+    pub fn xy_to_position(&self, x: i64, y: i64) -> i64 {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_TextCtrl_XYToPosition(ptr, x, y) }
+    }
+
+    /// Returns the number of lines in the text control.
+    /// Returns 0 if the control has been destroyed.
+    pub fn get_number_of_lines(&self) -> i32 {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_TextCtrl_GetNumberOfLines(ptr) }
+    }
+
+    /// Returns the length of the specified line (not including the trailing newline character).
+    /// Returns 0 if the line number is invalid or the control is destroyed.
+    pub fn get_line_length(&self, line_no: i64) -> i32 {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_TextCtrl_GetLineLength(ptr, line_no) }
+    }
+
+    /// Returns the contents of the given line.
+    /// Returns an empty string if the control has been destroyed.
+    pub fn get_line_text(&self, line_no: i64) -> String {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return String::new();
+        }
+        unsafe { Self::read_string_with_retry(|buf, len| ffi::wxd_TextCtrl_GetLineText(ptr, line_no, buf, len)) }
+    }
+
     /// Returns whether the text control has been modified by the user since the last
     /// time MarkDirty() or DiscardEdits() was called.
     /// Returns false if the control has been destroyed.
@@ -390,9 +486,91 @@ impl TextCtrl {
         unsafe { ffi::wxd_TextCtrl_SetInsertionPointEnd(ptr) };
     }
 
+    /// Sets the style for the given text range.
+    /// No-op if the control has been destroyed.
+    pub fn set_style(&self, start: i64, end: i64, style: &TextAttr) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_TextCtrl_SetStyle(ptr, start, end, style.as_ptr()) };
+    }
+
+    /// Returns the default style currently used for new text.
+    /// Returns None if the control has been destroyed.
+    pub fn get_default_style(&self) -> Option<TextAttr> {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return None;
+        }
+        let attr_ptr = unsafe { ffi::wxd_TextCtrl_GetDefaultStyle(ptr) };
+        if attr_ptr.is_null() {
+            return None;
+        }
+        Some(TextAttr { ptr: attr_ptr })
+    }
+
+    /// Sets the default style used for new text.
+    /// No-op if the control has been destroyed.
+    pub fn set_default_style(&self, style: &TextAttr) {
+        let ptr = self.textctrl_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_TextCtrl_SetDefaultStyle(ptr, style.as_ptr()) };
+    }
+
     /// Returns the underlying WindowHandle for this textctrl.
     pub fn window_handle(&self) -> WindowHandle {
         self.handle
+    }
+}
+
+/// Represents text attributes such as colors and fonts.
+pub struct TextAttr {
+    ptr: *mut ffi::wxd_TextAttr_t,
+}
+
+impl Default for TextAttr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TextAttr {
+    /// Creates a new default TextAttr.
+    pub fn new() -> Self {
+        Self {
+            ptr: unsafe { ffi::wxd_TextAttr_Create() },
+        }
+    }
+
+    /// Sets the text color.
+    pub fn set_text_colour(&mut self, color: crate::color::Colour) {
+        unsafe { ffi::wxd_TextAttr_SetTextColour(self.ptr, color.to_raw()) };
+    }
+
+    /// Sets the background color.
+    pub fn set_background_colour(&mut self, color: crate::color::Colour) {
+        unsafe { ffi::wxd_TextAttr_SetBackgroundColour(self.ptr, color.to_raw()) };
+    }
+
+    /// Sets the font.
+    pub fn set_font(&mut self, font: &crate::font::Font) {
+        unsafe { ffi::wxd_TextAttr_SetFont(self.ptr, font.as_ptr()) };
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut ffi::wxd_TextAttr_t {
+        self.ptr
+    }
+}
+
+impl Drop for TextAttr {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe { ffi::wxd_TextAttr_Delete(self.ptr) };
+            self.ptr = null_mut();
+        }
     }
 }
 


### PR DESCRIPTION
1. Rich Text Formatting (TextAttr)
- Introduced a safe Rust wrapper around wxd_TextAttr_t.
- Added methods to configure text styling: set_text_colour, set_background_colour, and set_font.
- Implemented the Drop trait for TextAttr to guarantee safe C++ memory deallocation when the styling object goes out of scope in Rust.
- Added set_style, get_default_style, and set_default_style to TextCtrl to apply these attributes.

2. Extended TextCtrl Capabilities
- Added text manipulation methods: write_text, change_value (which avoids triggering TextChanged events), replace, and remove.
- Added spatial and coordinate mapping methods: position_to_xy, xy_to_position, get_number_of_lines, and get_line_length.

3. Advanced Native Colour Dialogs
- Updated ColourDialogBuilder to support with_choose_full, allowing the dialog to open fully expanded with custom colour controls on Windows.
- Added with_custom_colour to pre-populate the 16 custom colour swatches at the bottom of the native dialog.
- Refactored the builder to safely handle the temporary wxColourData object only when custom data is provided.

