### PR TITLE
Wrap missing wxTextAttr methods to Rust

### DIFF
--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
@@ -98,6 +98,50 @@ wxd_TextAttr_SetParagraphSpacingBefore(wxd_TextAttr_t* attr, int spacing);
 WXD_EXPORTED void
 wxd_TextAttr_SetBulletStyle(wxd_TextAttr_t* attr, int style);
 
+WXD_EXPORTED void wxd_TextAttr_SetFlags(wxd_TextAttr_t* attr, wxd_Long_t flags);
+WXD_EXPORTED wxd_Long_t wxd_TextAttr_GetFlags(wxd_TextAttr_t* attr);
+WXD_EXPORTED bool wxd_TextAttr_HasFlag(wxd_TextAttr_t* attr, wxd_Long_t flag);
+
+WXD_EXPORTED void wxd_TextAttr_SetFontSize(wxd_TextAttr_t* attr, int pointSize);
+WXD_EXPORTED int wxd_TextAttr_GetFontSize(wxd_TextAttr_t* attr);
+
+WXD_EXPORTED void wxd_TextAttr_SetFontStyle(wxd_TextAttr_t* attr, int fontStyle);
+WXD_EXPORTED int wxd_TextAttr_GetFontStyle(wxd_TextAttr_t* attr);
+
+WXD_EXPORTED void wxd_TextAttr_SetFontWeight(wxd_TextAttr_t* attr, int fontWeight);
+WXD_EXPORTED int wxd_TextAttr_GetFontWeight(wxd_TextAttr_t* attr);
+
+WXD_EXPORTED void wxd_TextAttr_SetFontFaceName(wxd_TextAttr_t* attr, const char* faceName);
+WXD_EXPORTED void wxd_TextAttr_SetFontUnderlined(wxd_TextAttr_t* attr, bool underlined);
+WXD_EXPORTED void wxd_TextAttr_SetFontStrikethrough(wxd_TextAttr_t* attr, bool strikethrough);
+WXD_EXPORTED void wxd_TextAttr_SetFontEncoding(wxd_TextAttr_t* attr, int encoding);
+WXD_EXPORTED void wxd_TextAttr_SetFontFamily(wxd_TextAttr_t* attr, int family);
+
+WXD_EXPORTED void wxd_TextAttr_SetCharacterStyleName(wxd_TextAttr_t* attr, const char* name);
+WXD_EXPORTED void wxd_TextAttr_SetParagraphStyleName(wxd_TextAttr_t* attr, const char* name);
+WXD_EXPORTED void wxd_TextAttr_SetListStyleName(wxd_TextAttr_t* attr, const char* name);
+
+WXD_EXPORTED void wxd_TextAttr_SetBulletNumber(wxd_TextAttr_t* attr, int n);
+WXD_EXPORTED void wxd_TextAttr_SetBulletText(wxd_TextAttr_t* attr, const char* text);
+WXD_EXPORTED void wxd_TextAttr_SetBulletFont(wxd_TextAttr_t* attr, const char* bulletFont);
+WXD_EXPORTED void wxd_TextAttr_SetBulletName(wxd_TextAttr_t* attr, const char* name);
+WXD_EXPORTED void wxd_TextAttr_SetURL(wxd_TextAttr_t* attr, const char* url);
+WXD_EXPORTED void wxd_TextAttr_SetPageBreak(wxd_TextAttr_t* attr, bool pageBreak);
+WXD_EXPORTED void wxd_TextAttr_SetTextEffects(wxd_TextAttr_t* attr, int effects);
+WXD_EXPORTED void wxd_TextAttr_SetTextEffectFlags(wxd_TextAttr_t* attr, int effects);
+WXD_EXPORTED void wxd_TextAttr_SetOutlineLevel(wxd_TextAttr_t* attr, int level);
+
+WXD_EXPORTED wxd_Colour_t wxd_TextAttr_GetTextColour(wxd_TextAttr_t* attr);
+WXD_EXPORTED wxd_Colour_t wxd_TextAttr_GetBackgroundColour(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetAlignment(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetLeftIndent(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetLeftSubIndent(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetRightIndent(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetLineSpacing(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetParagraphSpacingAfter(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetParagraphSpacingBefore(wxd_TextAttr_t* attr);
+WXD_EXPORTED int wxd_TextAttr_GetBulletStyle(wxd_TextAttr_t* attr);
+
 // --- TextCtrl Style Functions ---
 WXD_EXPORTED void
 wxd_TextCtrl_SetStyle(wxd_TextCtrl_t* textCtrl, wxd_Long_t start, wxd_Long_t end, const wxd_TextAttr_t* style);

--- a/rust/wxdragon-sys/cpp/src/textctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/textctrl.cpp
@@ -365,6 +365,55 @@ wxd_TextAttr_SetBulletStyle(wxd_TextAttr_t* attr, int style)
     }
 }
 
+WXD_EXPORTED void wxd_TextAttr_SetFlags(wxd_TextAttr_t* attr, wxd_Long_t flags) { reinterpret_cast<wxTextAttr*>(attr)->SetFlags(flags); }
+WXD_EXPORTED wxd_Long_t wxd_TextAttr_GetFlags(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetFlags(); }
+WXD_EXPORTED bool wxd_TextAttr_HasFlag(wxd_TextAttr_t* attr, wxd_Long_t flag) { return reinterpret_cast<wxTextAttr*>(attr)->HasFlag(flag); }
+
+WXD_EXPORTED void wxd_TextAttr_SetFontSize(wxd_TextAttr_t* attr, int pointSize) { reinterpret_cast<wxTextAttr*>(attr)->SetFontSize(pointSize); }
+WXD_EXPORTED int wxd_TextAttr_GetFontSize(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetFontSize(); }
+
+WXD_EXPORTED void wxd_TextAttr_SetFontStyle(wxd_TextAttr_t* attr, int fontStyle) { reinterpret_cast<wxTextAttr*>(attr)->SetFontStyle(static_cast<wxFontStyle>(fontStyle)); }
+WXD_EXPORTED int wxd_TextAttr_GetFontStyle(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetFontStyle()); }
+
+WXD_EXPORTED void wxd_TextAttr_SetFontWeight(wxd_TextAttr_t* attr, int fontWeight) { reinterpret_cast<wxTextAttr*>(attr)->SetFontWeight(static_cast<wxFontWeight>(fontWeight)); }
+WXD_EXPORTED int wxd_TextAttr_GetFontWeight(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetFontWeight()); }
+
+WXD_EXPORTED void wxd_TextAttr_SetFontFaceName(wxd_TextAttr_t* attr, const char* faceName) { reinterpret_cast<wxTextAttr*>(attr)->SetFontFaceName(wxString::FromUTF8(faceName ? faceName : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetFontUnderlined(wxd_TextAttr_t* attr, bool underlined) { reinterpret_cast<wxTextAttr*>(attr)->SetFontUnderlined(underlined); }
+WXD_EXPORTED void wxd_TextAttr_SetFontStrikethrough(wxd_TextAttr_t* attr, bool strikethrough) { reinterpret_cast<wxTextAttr*>(attr)->SetFontStrikethrough(strikethrough); }
+WXD_EXPORTED void wxd_TextAttr_SetFontEncoding(wxd_TextAttr_t* attr, int encoding) { reinterpret_cast<wxTextAttr*>(attr)->SetFontEncoding(static_cast<wxFontEncoding>(encoding)); }
+WXD_EXPORTED void wxd_TextAttr_SetFontFamily(wxd_TextAttr_t* attr, int family) { reinterpret_cast<wxTextAttr*>(attr)->SetFontFamily(static_cast<wxFontFamily>(family)); }
+
+WXD_EXPORTED void wxd_TextAttr_SetCharacterStyleName(wxd_TextAttr_t* attr, const char* name) { reinterpret_cast<wxTextAttr*>(attr)->SetCharacterStyleName(wxString::FromUTF8(name ? name : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetParagraphStyleName(wxd_TextAttr_t* attr, const char* name) { reinterpret_cast<wxTextAttr*>(attr)->SetParagraphStyleName(wxString::FromUTF8(name ? name : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetListStyleName(wxd_TextAttr_t* attr, const char* name) { reinterpret_cast<wxTextAttr*>(attr)->SetListStyleName(wxString::FromUTF8(name ? name : "")); }
+
+WXD_EXPORTED void wxd_TextAttr_SetBulletNumber(wxd_TextAttr_t* attr, int n) { reinterpret_cast<wxTextAttr*>(attr)->SetBulletNumber(n); }
+WXD_EXPORTED void wxd_TextAttr_SetBulletText(wxd_TextAttr_t* attr, const char* text) { reinterpret_cast<wxTextAttr*>(attr)->SetBulletText(wxString::FromUTF8(text ? text : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetBulletFont(wxd_TextAttr_t* attr, const char* bulletFont) { reinterpret_cast<wxTextAttr*>(attr)->SetBulletFont(wxString::FromUTF8(bulletFont ? bulletFont : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetBulletName(wxd_TextAttr_t* attr, const char* name) { reinterpret_cast<wxTextAttr*>(attr)->SetBulletName(wxString::FromUTF8(name ? name : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetURL(wxd_TextAttr_t* attr, const char* url) { reinterpret_cast<wxTextAttr*>(attr)->SetURL(wxString::FromUTF8(url ? url : "")); }
+WXD_EXPORTED void wxd_TextAttr_SetPageBreak(wxd_TextAttr_t* attr, bool pageBreak) { reinterpret_cast<wxTextAttr*>(attr)->SetPageBreak(pageBreak); }
+WXD_EXPORTED void wxd_TextAttr_SetTextEffects(wxd_TextAttr_t* attr, int effects) { reinterpret_cast<wxTextAttr*>(attr)->SetTextEffects(effects); }
+WXD_EXPORTED void wxd_TextAttr_SetTextEffectFlags(wxd_TextAttr_t* attr, int effects) { reinterpret_cast<wxTextAttr*>(attr)->SetTextEffectFlags(effects); }
+WXD_EXPORTED void wxd_TextAttr_SetOutlineLevel(wxd_TextAttr_t* attr, int level) { reinterpret_cast<wxTextAttr*>(attr)->SetOutlineLevel(level); }
+
+static inline wxd_Colour_t from_wx(const wxColour& col) {
+    wxd_Colour_t c = { col.Red(), col.Green(), col.Blue(), col.Alpha() };
+    return c;
+}
+
+WXD_EXPORTED wxd_Colour_t wxd_TextAttr_GetTextColour(wxd_TextAttr_t* attr) { return from_wx(reinterpret_cast<wxTextAttr*>(attr)->GetTextColour()); }
+WXD_EXPORTED wxd_Colour_t wxd_TextAttr_GetBackgroundColour(wxd_TextAttr_t* attr) { return from_wx(reinterpret_cast<wxTextAttr*>(attr)->GetBackgroundColour()); }
+WXD_EXPORTED int wxd_TextAttr_GetAlignment(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetAlignment()); }
+WXD_EXPORTED int wxd_TextAttr_GetLeftIndent(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetLeftIndent()); }
+WXD_EXPORTED int wxd_TextAttr_GetLeftSubIndent(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetLeftSubIndent()); }
+WXD_EXPORTED int wxd_TextAttr_GetRightIndent(wxd_TextAttr_t* attr) { return static_cast<int>(reinterpret_cast<wxTextAttr*>(attr)->GetRightIndent()); }
+WXD_EXPORTED int wxd_TextAttr_GetLineSpacing(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetLineSpacing(); }
+WXD_EXPORTED int wxd_TextAttr_GetParagraphSpacingAfter(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetParagraphSpacingAfter(); }
+WXD_EXPORTED int wxd_TextAttr_GetParagraphSpacingBefore(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetParagraphSpacingBefore(); }
+WXD_EXPORTED int wxd_TextAttr_GetBulletStyle(wxd_TextAttr_t* attr) { return reinterpret_cast<wxTextAttr*>(attr)->GetBulletStyle(); }
+
 WXD_EXPORTED void
 wxd_TextCtrl_SetStyle(wxd_TextCtrl_t* textCtrl, wxd_Long_t start, wxd_Long_t end, const wxd_TextAttr_t* style)
 {

--- a/rust/wxdragon/src/widgets/textctrl.rs
+++ b/rust/wxdragon/src/widgets/textctrl.rs
@@ -560,6 +560,165 @@ impl TextAttr {
         unsafe { ffi::wxd_TextAttr_SetFont(self.ptr, font.as_ptr()) };
     }
 
+    /// Sets the text alignment.
+    pub fn set_alignment(&mut self, alignment: i32) {
+        unsafe { ffi::wxd_TextAttr_SetAlignment(self.ptr, alignment) };
+    }
+
+    /// Sets the left indent and sub-indent in tenths of a millimetre.
+    pub fn set_left_indent(&mut self, indent: i32, sub_indent: i32) {
+        unsafe { ffi::wxd_TextAttr_SetLeftIndent(self.ptr, indent, sub_indent) };
+    }
+
+    /// Sets the right indent in tenths of a millimetre.
+    pub fn set_right_indent(&mut self, indent: i32) {
+        unsafe { ffi::wxd_TextAttr_SetRightIndent(self.ptr, indent) };
+    }
+
+    /// Sets the line spacing. 10 is normal, 15 is 1.5, 20 is double.
+    pub fn set_line_spacing(&mut self, spacing: i32) {
+        unsafe { ffi::wxd_TextAttr_SetLineSpacing(self.ptr, spacing) };
+    }
+
+    /// Sets the paragraph spacing after in tenths of a millimetre.
+    pub fn set_paragraph_spacing_after(&mut self, spacing: i32) {
+        unsafe { ffi::wxd_TextAttr_SetParagraphSpacingAfter(self.ptr, spacing) };
+    }
+
+    /// Sets the paragraph spacing before in tenths of a millimetre.
+    pub fn set_paragraph_spacing_before(&mut self, spacing: i32) {
+        unsafe { ffi::wxd_TextAttr_SetParagraphSpacingBefore(self.ptr, spacing) };
+    }
+
+    /// Sets the bullet style.
+    pub fn set_bullet_style(&mut self, style: i32) {
+        unsafe { ffi::wxd_TextAttr_SetBulletStyle(self.ptr, style) };
+    }
+
+    pub fn set_flags(&mut self, flags: i64) {
+        unsafe { ffi::wxd_TextAttr_SetFlags(self.ptr, flags) };
+    }
+    pub fn get_flags(&self) -> i64 {
+        unsafe { ffi::wxd_TextAttr_GetFlags(self.ptr) }
+    }
+    pub fn has_flag(&self, flag: i64) -> bool {
+        unsafe { ffi::wxd_TextAttr_HasFlag(self.ptr, flag) }
+    }
+
+    pub fn set_font_size(&mut self, point_size: i32) {
+        unsafe { ffi::wxd_TextAttr_SetFontSize(self.ptr, point_size) };
+    }
+    pub fn get_font_size(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetFontSize(self.ptr) }
+    }
+
+    pub fn set_font_style(&mut self, font_style: crate::font::FontStyle) {
+        unsafe { ffi::wxd_TextAttr_SetFontStyle(self.ptr, font_style as i32) };
+    }
+    pub fn get_font_style(&self) -> crate::font::FontStyle {
+        unsafe { std::mem::transmute(ffi::wxd_TextAttr_GetFontStyle(self.ptr)) }
+    }
+
+    pub fn set_font_weight(&mut self, font_weight: crate::font::FontWeight) {
+        unsafe { ffi::wxd_TextAttr_SetFontWeight(self.ptr, font_weight as i32) };
+    }
+    pub fn get_font_weight(&self) -> crate::font::FontWeight {
+        unsafe { std::mem::transmute(ffi::wxd_TextAttr_GetFontWeight(self.ptr)) }
+    }
+
+    pub fn set_font_face_name(&mut self, face_name: &str) {
+        let c_str = std::ffi::CString::new(face_name).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetFontFaceName(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_font_underlined(&mut self, underlined: bool) {
+        unsafe { ffi::wxd_TextAttr_SetFontUnderlined(self.ptr, underlined) };
+    }
+    pub fn set_font_strikethrough(&mut self, strikethrough: bool) {
+        unsafe { ffi::wxd_TextAttr_SetFontStrikethrough(self.ptr, strikethrough) };
+    }
+    pub fn set_font_encoding(&mut self, encoding: i32) {
+        unsafe { ffi::wxd_TextAttr_SetFontEncoding(self.ptr, encoding) };
+    }
+    pub fn set_font_family(&mut self, family: crate::font::FontFamily) {
+        unsafe { ffi::wxd_TextAttr_SetFontFamily(self.ptr, family as i32) };
+    }
+
+    pub fn set_character_style_name(&mut self, name: &str) {
+        let c_str = std::ffi::CString::new(name).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetCharacterStyleName(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_paragraph_style_name(&mut self, name: &str) {
+        let c_str = std::ffi::CString::new(name).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetParagraphStyleName(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_list_style_name(&mut self, name: &str) {
+        let c_str = std::ffi::CString::new(name).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetListStyleName(self.ptr, c_str.as_ptr()) };
+    }
+
+    pub fn set_bullet_number(&mut self, n: i32) {
+        unsafe { ffi::wxd_TextAttr_SetBulletNumber(self.ptr, n) };
+    }
+    pub fn set_bullet_text(&mut self, text: &str) {
+        let c_str = std::ffi::CString::new(text).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetBulletText(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_bullet_font(&mut self, bullet_font: &str) {
+        let c_str = std::ffi::CString::new(bullet_font).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetBulletFont(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_bullet_name(&mut self, name: &str) {
+        let c_str = std::ffi::CString::new(name).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetBulletName(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_url(&mut self, url: &str) {
+        let c_str = std::ffi::CString::new(url).unwrap();
+        unsafe { ffi::wxd_TextAttr_SetURL(self.ptr, c_str.as_ptr()) };
+    }
+    pub fn set_page_break(&mut self, page_break: bool) {
+        unsafe { ffi::wxd_TextAttr_SetPageBreak(self.ptr, page_break) };
+    }
+    pub fn set_text_effects(&mut self, effects: i32) {
+        unsafe { ffi::wxd_TextAttr_SetTextEffects(self.ptr, effects) };
+    }
+    pub fn set_text_effect_flags(&mut self, effects: i32) {
+        unsafe { ffi::wxd_TextAttr_SetTextEffectFlags(self.ptr, effects) };
+    }
+    pub fn set_outline_level(&mut self, level: i32) {
+        unsafe { ffi::wxd_TextAttr_SetOutlineLevel(self.ptr, level) };
+    }
+
+    pub fn get_text_colour(&self) -> crate::color::Colour {
+        crate::color::Colour::from(unsafe { ffi::wxd_TextAttr_GetTextColour(self.ptr) })
+    }
+    pub fn get_background_colour(&self) -> crate::color::Colour {
+        crate::color::Colour::from(unsafe { ffi::wxd_TextAttr_GetBackgroundColour(self.ptr) })
+    }
+    pub fn get_alignment(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetAlignment(self.ptr) }
+    }
+    pub fn get_left_indent(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetLeftIndent(self.ptr) }
+    }
+    pub fn get_left_sub_indent(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetLeftSubIndent(self.ptr) }
+    }
+    pub fn get_right_indent(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetRightIndent(self.ptr) }
+    }
+    pub fn get_line_spacing(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetLineSpacing(self.ptr) }
+    }
+    pub fn get_paragraph_spacing_after(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetParagraphSpacingAfter(self.ptr) }
+    }
+    pub fn get_paragraph_spacing_before(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetParagraphSpacingBefore(self.ptr) }
+    }
+    pub fn get_bullet_style(&self) -> i32 {
+        unsafe { ffi::wxd_TextAttr_GetBulletStyle(self.ptr) }
+    }
+
     pub(crate) fn as_ptr(&self) -> *mut ffi::wxd_TextAttr_t {
         self.ptr
     }


### PR DESCRIPTION
- Add missing getters and setters to wxTextAttr C++ bridge layer.

- Add safe Rust wrappers for all missing font, formatting, bullet, list, and style name methods in TextAttr.
