### PR TITLE
Fix ARM64 MSVC library search path handling

### DIFF
--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -494,7 +494,7 @@ fn build_wxdragon_wrapper(
             let wx_lib_widgets = wxwidgets_build_dir.join(lib_dir).display().to_string();
             println!("cargo:rustc-link-search=native={wx_lib_widgets}");
 
-            if target == "i686-pc-windows-msvc" {
+            if target == "i686-pc-windows-msvc" || target == "aarch64-pc-windows-msvc" {
                 // build/lib/Debug or build/lib/Release
                 let sub_dir = format!("build/lib/{profile}");
                 let wx_lib3 = wxdragon_sys_build_dir.join(sub_dir).display().to_string();


### PR DESCRIPTION
Adds `aarch64-pc-windows-msvc` to the existing Visual Studio/MSVC library search path handling logic.

ARM64 Windows builds place generated libraries in the same `build/lib/{profile}` output directory pattern as the existing `i686-pc-windows-msvc` case, but the ARM64 target was not included in the additional `rustc-link-search` path setup.

Without this change, linking can fail with:

```text
could not find native static library `wxdragon`
```

during ARM64 Windows builds.

## Changes

* Extend the conditional library search path logic to include:

  * `aarch64-pc-windows-msvc`

## Result

ARM64 MSVC builds can now locate the generated `wxdragon.lib` output correctly.