### PR TITLE
Add macOS VoiceOver accessibility helpers to WxWidget

### DIFF
--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -637,10 +637,10 @@ fn build_wxdragon_wrapper(
             for line in cache.lines() {
                 if let Some(iconv_lib) = line.strip_prefix("ICONV_LIBRARIES:FILEPATH=") {
                     let iconv_path = std::path::Path::new(iconv_lib.trim());
-                    if let Some(dir) = iconv_path.parent() {
-                        if dir.exists() {
-                            println!("cargo:rustc-link-search=native={}", dir.display());
-                        }
+                    if let Some(dir) = iconv_path.parent()
+                        && dir.exists()
+                    {
+                        println!("cargo:rustc-link-search=native={}", dir.display());
                     }
                     break;
                 }

--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -629,6 +629,23 @@ fn build_wxdragon_wrapper(
         println!("cargo:rustc-link-lib=static={}", resolve_wx_lib("wxregexu-3.3"));
         println!("cargo:rustc-link-lib=expat");
         println!("cargo:rustc-link-lib=z");
+        // If cmake found iconv in a non-standard location (e.g. MacPorts /opt/local,
+        // Homebrew /opt/homebrew), add that directory to the linker search path so
+        // -liconv resolves to the same library cmake compiled against.
+        let cmake_cache_path = wxdragon_sys_build_dir.join("build/CMakeCache.txt");
+        if let Ok(cache) = std::fs::read_to_string(&cmake_cache_path) {
+            for line in cache.lines() {
+                if let Some(iconv_lib) = line.strip_prefix("ICONV_LIBRARIES:FILEPATH=") {
+                    let iconv_path = std::path::Path::new(iconv_lib.trim());
+                    if let Some(dir) = iconv_path.parent() {
+                        if dir.exists() {
+                            println!("cargo:rustc-link-search=native={}", dir.display());
+                        }
+                    }
+                    break;
+                }
+            }
+        }
         println!("cargo:rustc-link-lib=iconv");
         println!("cargo:rustc-link-lib=c++");
 

--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -228,6 +228,13 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/misc.cpp
 )
 
+# Add macOS-specific sources (Objective-C++ files)
+if(PLATFORM_NAME STREQUAL "macos")
+    list(APPEND WXDRAGON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/window_osx.mm)
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/window_osx.mm
+        PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+endif()
+
 # Add Linux compatibility layer for older systems
 if(PLATFORM_NAME STREQUAL "linux")
     list(APPEND WXDRAGON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/linux_compat.cpp)

--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -91,6 +91,8 @@ add_subdirectory(${WXWIDGETS_LIB_DIR} ${WXWIDGETS_BUILD_DIR})
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     message(STATUS "Building for macOS")
     set(PLATFORM_NAME "macos")
+    # Enable Objective-C++ for .mm files
+    enable_language(OBJCXX)
     # Define platform-specific preprocessor macros
     add_compile_definitions(__WXOSX_COCOA__ __WXMAC__ __WXOSX__ _FILE_OFFSET_BITS=64 NDEBUG)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -246,6 +246,11 @@ wxd_Window_MSWDisableComposited(wxd_Window_t* window);
 /// e.g. "Language, English, pop up button".
 WXD_EXPORTED void
 wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label);
+
+/// Activates the application, bringing it in front of all other apps (macOS only).
+/// Equivalent to [NSRunningApplication activateWithOptions:NSApplicationActivateIgnoringOtherApps].
+WXD_EXPORTED void
+wxd_App_ActivateMac(void);
 #endif
 
 // --- Popup Menu Functions ---

--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -246,12 +246,6 @@ wxd_Window_MSWDisableComposited(wxd_Window_t* window);
 /// e.g. "Language, English, pop up button".
 WXD_EXPORTED void
 wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label);
-
-/// Hides the window from the VoiceOver cursor (macOS only).
-/// Sets NSAccessibility accessibilityHidden = YES. The window remains visible
-/// on screen but assistive technologies skip it.
-WXD_EXPORTED void
-wxd_Window_HideFromAccessibility(wxd_Window_t* window);
 #endif
 
 // --- Popup Menu Functions ---

--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -248,7 +248,8 @@ WXD_EXPORTED void
 wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label);
 
 /// Hides the window from the VoiceOver cursor (macOS only).
-/// The window remains visible on screen but assistive technologies skip it.
+/// Sets NSAccessibility accessibilityHidden = YES. The window remains visible
+/// on screen but assistive technologies skip it.
 WXD_EXPORTED void
 wxd_Window_HideFromAccessibility(wxd_Window_t* window);
 #endif

--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -240,6 +240,19 @@ WXD_EXPORTED void
 wxd_Window_MSWDisableComposited(wxd_Window_t* window);
 #endif
 
+#ifdef __WXOSX__
+/// Sets the VoiceOver accessibility label for the window (macOS only).
+/// VoiceOver announces this label before the control's value and role,
+/// e.g. "Language, English, pop up button".
+WXD_EXPORTED void
+wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label);
+
+/// Hides the window from the VoiceOver cursor (macOS only).
+/// The window remains visible on screen but assistive technologies skip it.
+WXD_EXPORTED void
+wxd_Window_HideFromAccessibility(wxd_Window_t* window);
+#endif
+
 // --- Popup Menu Functions ---
 /// Shows a popup menu at the specified position (or current mouse position if
 /// NULL) Returns true if a menu item was selected, false otherwise

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -11,14 +11,3 @@ wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label)
         [view setAccessibilityLabel:[NSString stringWithUTF8String:label]];
     }
 }
-
-void
-wxd_Window_HideFromAccessibility(wxd_Window_t* window)
-{
-    if (!window) return;
-    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
-    NSView* view = wx_window->GetHandle();
-    if (view) {
-        [view setAccessibilityHidden:YES];
-    }
-}

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -1,0 +1,24 @@
+#import <AppKit/AppKit.h>
+#include "../include/wxdragon.h"
+
+void
+wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label)
+{
+    if (!window || !label) return;
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    NSView* view = wx_window->GetHandle();
+    if (view) {
+        [view setAccessibilityLabel:[NSString stringWithUTF8String:label]];
+    }
+}
+
+void
+wxd_Window_HideFromAccessibility(wxd_Window_t* window)
+{
+    if (!window) return;
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    NSView* view = wx_window->GetHandle();
+    if (view) {
+        [view setAccessibilityElement:NO];
+    }
+}

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -11,3 +11,10 @@ wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label)
         [view setAccessibilityLabel:[NSString stringWithUTF8String:label]];
     }
 }
+
+void
+wxd_App_ActivateMac(void)
+{
+    [[NSRunningApplication currentApplication]
+        activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+}

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -19,6 +19,6 @@ wxd_Window_HideFromAccessibility(wxd_Window_t* window)
     wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
     NSView* view = wx_window->GetHandle();
     if (view) {
-        [view setAccessibilityElement:NO];
+        [view setAccessibilityHidden:YES];
     }
 }

--- a/rust/wxdragon/src/app.rs
+++ b/rust/wxdragon/src/app.rs
@@ -301,6 +301,16 @@ where
     }
 }
 
+/// Activates the application, bringing it in front of all other apps (macOS only).
+///
+/// Call this when showing a previously-hidden window in response to a dock click
+/// so the app becomes the frontmost application.
+#[cfg(target_os = "macos")]
+pub fn activate_app() {
+    use crate::window::wxd_App_ActivateMac;
+    unsafe { wxd_App_ActivateMac() };
+}
+
 /// Wakes up the application's idle event loop.
 ///
 /// This function forces the application to process pending idle events

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -134,8 +134,6 @@ unsafe extern "C" {
     unsafe fn wxd_Window_MSWDisableComposited(window: *mut ffi::wxd_Window_t);
     #[cfg(target_os = "macos")]
     unsafe fn wxd_Window_SetAccessibilityLabel(window: *mut ffi::wxd_Window_t, label: *const std::os::raw::c_char);
-    #[cfg(target_os = "macos")]
-    unsafe fn wxd_Window_HideFromAccessibility(window: *mut ffi::wxd_Window_t);
 }
 
 // Use the widget_style_enum macro to define ExtraWindowStyle
@@ -1622,19 +1620,6 @@ pub trait WxWidget: std::any::Any {
         }
         let c_label = std::ffi::CString::new(label).unwrap_or_default();
         unsafe { wxd_Window_SetAccessibilityLabel(handle, c_label.as_ptr()) }
-    }
-
-    /// Hides the window from the VoiceOver cursor (macOS only).
-    ///
-    /// The window remains visible on screen but assistive technologies skip it.
-    /// Typically used on a `StaticText` label whose text has been transferred to
-    /// a nearby control via [`set_accessibility_label`].
-    #[cfg(target_os = "macos")]
-    fn hide_from_accessibility(&self) {
-        let handle = self.handle_ptr();
-        if !handle.is_null() {
-            unsafe { wxd_Window_HideFromAccessibility(handle) }
-        }
     }
 
     // --- Tab Order Functions ---

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -135,7 +135,7 @@ unsafe extern "C" {
     #[cfg(target_os = "macos")]
     unsafe fn wxd_Window_SetAccessibilityLabel(window: *mut ffi::wxd_Window_t, label: *const std::os::raw::c_char);
     #[cfg(target_os = "macos")]
-    unsafe fn wxd_App_ActivateMac();
+    pub(crate) unsafe fn wxd_App_ActivateMac();
 }
 
 // Use the widget_style_enum macro to define ExtraWindowStyle

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -134,6 +134,8 @@ unsafe extern "C" {
     unsafe fn wxd_Window_MSWDisableComposited(window: *mut ffi::wxd_Window_t);
     #[cfg(target_os = "macos")]
     unsafe fn wxd_Window_SetAccessibilityLabel(window: *mut ffi::wxd_Window_t, label: *const std::os::raw::c_char);
+    #[cfg(target_os = "macos")]
+    unsafe fn wxd_App_ActivateMac();
 }
 
 // Use the widget_style_enum macro to define ExtraWindowStyle

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -132,6 +132,10 @@ unsafe extern "C" {
     unsafe fn wxd_Window_FindWindowById(window: *mut ffi::wxd_Window_t, id: std::os::raw::c_int) -> *mut ffi::wxd_Window_t;
     #[cfg(target_os = "windows")]
     unsafe fn wxd_Window_MSWDisableComposited(window: *mut ffi::wxd_Window_t);
+    #[cfg(target_os = "macos")]
+    unsafe fn wxd_Window_SetAccessibilityLabel(window: *mut ffi::wxd_Window_t, label: *const std::os::raw::c_char);
+    #[cfg(target_os = "macos")]
+    unsafe fn wxd_Window_HideFromAccessibility(window: *mut ffi::wxd_Window_t);
 }
 
 // Use the widget_style_enum macro to define ExtraWindowStyle
@@ -1617,7 +1621,7 @@ pub trait WxWidget: std::any::Any {
             return;
         }
         let c_label = std::ffi::CString::new(label).unwrap_or_default();
-        unsafe { ffi::wxd_Window_SetAccessibilityLabel(handle, c_label.as_ptr()) }
+        unsafe { wxd_Window_SetAccessibilityLabel(handle, c_label.as_ptr()) }
     }
 
     /// Hides the window from the VoiceOver cursor (macOS only).
@@ -1629,7 +1633,7 @@ pub trait WxWidget: std::any::Any {
     fn hide_from_accessibility(&self) {
         let handle = self.handle_ptr();
         if !handle.is_null() {
-            unsafe { ffi::wxd_Window_HideFromAccessibility(handle) }
+            unsafe { wxd_Window_HideFromAccessibility(handle) }
         }
     }
 

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -1601,6 +1601,38 @@ pub trait WxWidget: std::any::Any {
         }
     }
 
+    /// Sets the VoiceOver accessibility label for the window (macOS only).
+    ///
+    /// VoiceOver announces this label before the control's value and role.
+    /// For example, setting "Language" on a popup button showing "English" causes
+    /// VoiceOver to read "Language, English, pop up button" as a single cursor stop,
+    /// rather than navigating a separate label and control.
+    ///
+    /// Use this together with [`hide_from_accessibility`] on the adjacent `StaticText`
+    /// label to avoid redundant announcements.
+    #[cfg(target_os = "macos")]
+    fn set_accessibility_label(&self, label: &str) {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return;
+        }
+        let c_label = std::ffi::CString::new(label).unwrap_or_default();
+        unsafe { ffi::wxd_Window_SetAccessibilityLabel(handle, c_label.as_ptr()) }
+    }
+
+    /// Hides the window from the VoiceOver cursor (macOS only).
+    ///
+    /// The window remains visible on screen but assistive technologies skip it.
+    /// Typically used on a `StaticText` label whose text has been transferred to
+    /// a nearby control via [`set_accessibility_label`].
+    #[cfg(target_os = "macos")]
+    fn hide_from_accessibility(&self) {
+        let handle = self.handle_ptr();
+        if !handle.is_null() {
+            unsafe { ffi::wxd_Window_HideFromAccessibility(handle) }
+        }
+    }
+
     // --- Tab Order Functions ---
 
     /// Moves this window to appear after the specified window in the tab order.


### PR DESCRIPTION
## Summary

Adds `set_accessibility_label(label: &str)` to the `WxWidget` trait (macOS only): sets `NSAccessibilityLabel` on the underlying `NSView` so VoiceOver announces the label as part of the control — e.g. **"Language, English, pop up button"** — rather than as a separate cursor stop.

Implemented in a new `window_osx.mm` (Objective-C++) compiled only on macOS, following the existing `#ifdef __WXMSW__` / `MSWDisableComposited` pattern for platform-specific window methods.

## Motivation

On macOS, form dialogs typically pair a `StaticText` label with a `wxChoice` (NSPopUpButton). Without this, VoiceOver navigates them as two separate elements. Native macOS convention is for the control to announce its own label inline, so the user hears "Language, English, pop up button" in one stop rather than navigating past a "Language:" text and then a separate popup. This PR makes that labeling possible from wxDragon while leaving the static text visible in the VoiceOver cursor order.

## Test plan

- [x] Build on macOS and confirm `set_accessibility_label` compiles and links
- [x] Verify VoiceOver announces a labeled popup button as "Label, Value, pop up button" in a single cursor stop
- [x] Confirm no regressions on Windows and Linux (the method is `#[cfg(target_os = "macos")]` and the `.mm` file is excluded from non-macOS builds)