### PR TITLE
Add custom Rust-backed translations loader

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_translations.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_translations.h
@@ -99,6 +99,47 @@ wxd_Translations_GetAvailableTranslations(wxd_Translations_t* translations,
                                           size_t buffer_count,
                                           size_t string_buffer_len);
 
+// --- Custom (Rust-backed) translations loader ---
+
+// A set of callbacks that back a custom wxTranslationsLoader implemented on the
+// Rust side. The C++ trampoline only constructs the wxWidgets objects the
+// callbacks cannot (wxMsgCatalog / wxArrayString); all loader policy lives in
+// Rust.
+// Sink used by load_catalog to hand catalog bytes to C++. `emit` must be called
+// (at most once) while the bytes are still alive; C++ parses them synchronously.
+typedef void (*wxd_TranslationsCatalogSink)(void* sink, const uint8_t* data, size_t len);
+
+typedef struct wxd_RustTranslationsLoader_vtable {
+    // Provide the raw .mo catalog bytes for (domain, lang) by calling
+    // `emit(sink, data, len)` exactly once with the bytes while they are alive;
+    // C++ builds the catalog synchronously inside `emit`. Return true if a
+    // catalog was emitted, false if unavailable. Passing bytes through `emit`
+    // (rather than out-params C++ reads after the call) lets a loader return
+    // freshly-computed/owned bytes (e.g. decompressed) as well as borrowed ones;
+    // the bytes only need to outlive the `emit` call.
+    bool (*load_catalog)(void* user_data,
+                         const char* domain,
+                         const char* lang,
+                         void* sink,
+                         wxd_TranslationsCatalogSink emit);
+
+    // Append every available language for `domain` to `out` (a wxArrayString)
+    // via wxd_ArrayString_Add.
+    void (*available)(void* user_data, const char* domain, wxd_ArrayString_t* out);
+
+    // Release user_data. Called from the loader's destructor.
+    void (*destroy)(void* user_data);
+} wxd_RustTranslationsLoader_vtable;
+
+// Install a Rust-backed loader on `translations`, replacing any existing loader.
+// wxTranslations takes ownership of the loader; the vtable is copied, so it need
+// not outlive this call. `user_data` is owned by the loader and released via
+// vtable.destroy when the loader is destroyed.
+WXD_EXPORTED void
+wxd_Translations_SetRustLoader(wxd_Translations_t* translations,
+                               const wxd_RustTranslationsLoader_vtable* vtable,
+                               void* user_data);
+
 // --- FileTranslationsLoader Functions ---
 
 // Add a catalog lookup path prefix (static method)

--- a/rust/wxdragon-sys/cpp/include/core/wxd_translations.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_translations.h
@@ -105,18 +105,19 @@ wxd_Translations_GetAvailableTranslations(wxd_Translations_t* translations,
 // Rust side. The C++ trampoline only constructs the wxWidgets objects the
 // callbacks cannot (wxMsgCatalog / wxArrayString); all loader policy lives in
 // Rust.
-// Sink used by load_catalog to hand catalog bytes to C++. `emit` must be called
-// (at most once) while the bytes are still alive; C++ parses them synchronously.
+
+// Sink handed to load_catalog. CATALOG-BYTES CONTRACT (single source of truth,
+// referenced from the C++ and Rust trampolines): load_catalog calls
+// emit(sink, data, len) exactly once with the bytes still alive; C++ wraps them
+// non-owning and parses synchronously inside emit (wxMsgCatalog does not retain
+// the buffer), so the bytes need only outlive the emit call — borrowed or
+// freshly-owned bytes both work.
 typedef void (*wxd_TranslationsCatalogSink)(void* sink, const uint8_t* data, size_t len);
 
 typedef struct wxd_RustTranslationsLoader_vtable {
-    // Provide the raw .mo catalog bytes for (domain, lang) by calling
-    // `emit(sink, data, len)` exactly once with the bytes while they are alive;
-    // C++ builds the catalog synchronously inside `emit`. Return true if a
-    // catalog was emitted, false if unavailable. Passing bytes through `emit`
-    // (rather than out-params C++ reads after the call) lets a loader return
-    // freshly-computed/owned bytes (e.g. decompressed) as well as borrowed ones;
-    // the bytes only need to outlive the `emit` call.
+    // Provide the raw .mo catalog bytes for (domain, lang) via `emit` (see the
+    // wxd_TranslationsCatalogSink contract above). Return true if a catalog was
+    // emitted, false if unavailable.
     bool (*load_catalog)(void* user_data,
                          const char* domain,
                          const char* lang,

--- a/rust/wxdragon-sys/cpp/src/translations.cpp
+++ b/rust/wxdragon-sys/cpp/src/translations.cpp
@@ -24,9 +24,8 @@ public:
             m_vtable.destroy(m_user_data);
     }
 
-    // Context passed as the `sink` to the Rust load_catalog callback. Rust calls
-    // emit_catalog(sink, data, len) while the bytes are alive; we build the
-    // catalog right there.
+    // Context passed as the `sink` to load_catalog; see the
+    // wxd_TranslationsCatalogSink contract in wxd_translations.h.
     struct CatalogSink
     {
         const wxString* domain;
@@ -38,9 +37,8 @@ public:
         if (!sink || !data)
             return;
         CatalogSink* s = reinterpret_cast<CatalogSink*>(sink);
-        // Bytes are consumed synchronously; wxMsgCatalog parses into its own
-        // hash and does not retain the buffer, so a non-owned view is safe even
-        // when the Rust side owns (and will drop) the bytes after this returns.
+        // Non-owning view is safe per the contract: consumed synchronously here,
+        // wxMsgCatalog does not retain the buffer.
         s->catalog = wxMsgCatalog::CreateFromData(
             wxScopedCharBuffer::CreateNonOwned(
                 reinterpret_cast<const char*>(data), len),

--- a/rust/wxdragon-sys/cpp/src/translations.cpp
+++ b/rust/wxdragon-sys/cpp/src/translations.cpp
@@ -4,6 +4,77 @@
 #include <wx/translation.h>
 #include <wx/intl.h>
 #include <wx/uilocale.h>
+#include <wx/arrstr.h>
+
+// A wxTranslationsLoader that forwards to Rust callbacks. The C++ side is a
+// dumb trampoline: it only builds the wxWidgets objects the callbacks cannot
+// (wxMsgCatalog / wxArrayString); all loader policy lives in Rust.
+class WxdRustTranslationsLoader : public wxTranslationsLoader
+{
+public:
+    WxdRustTranslationsLoader(const wxd_RustTranslationsLoader_vtable* vtable,
+                              void* user_data)
+        : m_vtable(*vtable), m_user_data(user_data)
+    {
+    }
+
+    ~WxdRustTranslationsLoader() override
+    {
+        if (m_vtable.destroy)
+            m_vtable.destroy(m_user_data);
+    }
+
+    // Context passed as the `sink` to the Rust load_catalog callback. Rust calls
+    // emit_catalog(sink, data, len) while the bytes are alive; we build the
+    // catalog right there.
+    struct CatalogSink
+    {
+        const wxString* domain;
+        wxMsgCatalog* catalog;
+    };
+
+    static void emit_catalog(void* sink, const uint8_t* data, size_t len)
+    {
+        if (!sink || !data)
+            return;
+        CatalogSink* s = reinterpret_cast<CatalogSink*>(sink);
+        // Bytes are consumed synchronously; wxMsgCatalog parses into its own
+        // hash and does not retain the buffer, so a non-owned view is safe even
+        // when the Rust side owns (and will drop) the bytes after this returns.
+        s->catalog = wxMsgCatalog::CreateFromData(
+            wxScopedCharBuffer::CreateNonOwned(
+                reinterpret_cast<const char*>(data), len),
+            *s->domain);
+    }
+
+    wxMsgCatalog* LoadCatalog(const wxString& domain,
+                              const wxString& lang) override
+    {
+        if (!m_vtable.load_catalog)
+            return nullptr;
+        const wxScopedCharBuffer domainUtf8 = domain.utf8_str();
+        const wxScopedCharBuffer langUtf8 = lang.utf8_str();
+        CatalogSink sink{ &domain, nullptr };
+        m_vtable.load_catalog(m_user_data, domainUtf8.data(), langUtf8.data(),
+                              &sink, &emit_catalog);
+        return sink.catalog;
+    }
+
+    wxArrayString GetAvailableTranslations(const wxString& domain) const override
+    {
+        wxArrayString langs;
+        if (m_vtable.available) {
+            const wxScopedCharBuffer domainUtf8 = domain.utf8_str();
+            m_vtable.available(m_user_data, domainUtf8.data(),
+                               reinterpret_cast<wxd_ArrayString_t*>(&langs));
+        }
+        return langs;
+    }
+
+private:
+    wxd_RustTranslationsLoader_vtable m_vtable;
+    void* m_user_data;
+};
 
 extern "C" {
 
@@ -245,6 +316,21 @@ wxd_Translations_GetAvailableTranslations(wxd_Translations_t* translations,
     }
 
     return count;
+}
+
+void
+wxd_Translations_SetRustLoader(wxd_Translations_t* translations,
+                               const wxd_RustTranslationsLoader_vtable* vtable,
+                               void* user_data)
+{
+    if (!translations || !vtable)
+        return;
+    wxTranslations* wx_translations =
+        reinterpret_cast<wxTranslations*>(translations);
+    // wxTranslations takes ownership of the loader and deletes it (calling our
+    // destructor, which releases user_data via vtable.destroy).
+    wx_translations->SetLoader(
+        new WxdRustTranslationsLoader(vtable, user_data));
 }
 
 void

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -226,8 +226,7 @@ pub use crate::ipc::{IPCClient, IPCConnection, IPCConnectionBuilder, IPCFormat, 
 pub use crate::single_instance_checker::SingleInstanceChecker;
 pub use crate::timer::Timer;
 pub use crate::translations::{
-    LanguageInfo, Locale, Translations, TranslationsLoader, add_catalog_lookup_path_prefix, translate,
-    translate_plural,
+    LanguageInfo, Locale, Translations, TranslationsLoader, add_catalog_lookup_path_prefix, translate, translate_plural,
 };
 pub use crate::uiactionsimulator::{KeyModifier, MouseButton, UIActionSimulator};
 

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -225,7 +225,10 @@ pub use crate::appprogress::AppProgressIndicator;
 pub use crate::ipc::{IPCClient, IPCConnection, IPCConnectionBuilder, IPCFormat, IPCServer};
 pub use crate::single_instance_checker::SingleInstanceChecker;
 pub use crate::timer::Timer;
-pub use crate::translations::{LanguageInfo, Locale, Translations, add_catalog_lookup_path_prefix, translate, translate_plural};
+pub use crate::translations::{
+    LanguageInfo, Locale, Translations, TranslationsLoader, add_catalog_lookup_path_prefix, translate,
+    translate_plural,
+};
 pub use crate::uiactionsimulator::{KeyModifier, MouseButton, UIActionSimulator};
 
 // --- Constants for specific widgets that might be commonly used ---

--- a/rust/wxdragon/src/translations.rs
+++ b/rust/wxdragon/src/translations.rs
@@ -484,8 +484,7 @@ unsafe extern "C" fn loader_available(user_data: *mut c_void, domain: *const c_c
         let domain = CStr::from_ptr(domain).to_string_lossy();
         // Borrow (non-owning) the C++-owned array and reuse the shared wrapper's
         // CString + Add loop instead of hand-rolling it.
-        ArrayString::from(out as *const ffi::wxd_ArrayString_t)
-            .add_many(&loader.available_translations(&domain));
+        ArrayString::from(out as *const ffi::wxd_ArrayString_t).add_many(&loader.available_translations(&domain));
     }
 }
 

--- a/rust/wxdragon/src/translations.rs
+++ b/rust/wxdragon/src/translations.rs
@@ -191,9 +191,7 @@ impl Translations {
         // Double-box: `Box<dyn Trait>` is a fat pointer, so box it again to get
         // a thin `*mut c_void` we can hand across FFI. Freed by `loader_destroy`.
         let user_data = Box::into_raw(Box::new(Box::new(loader) as Box<dyn TranslationsLoader>)) as *mut c_void;
-        unsafe {
-            ffi::wxd_Translations_SetRustLoader(self.ptr, &LOADER_VTABLE as *const _, user_data)
-        };
+        unsafe { ffi::wxd_Translations_SetRustLoader(self.ptr, &LOADER_VTABLE as *const _, user_data) };
     }
 
     /// Check if a catalog for the given domain is loaded.
@@ -476,11 +474,7 @@ unsafe extern "C" fn loader_load_catalog(
     }
 }
 
-unsafe extern "C" fn loader_available(
-    user_data: *mut c_void,
-    domain: *const c_char,
-    out: *mut ffi::wxd_ArrayString_t,
-) {
+unsafe extern "C" fn loader_available(user_data: *mut c_void, domain: *const c_char, out: *mut ffi::wxd_ArrayString_t) {
     if user_data.is_null() || domain.is_null() || out.is_null() {
         return;
     }
@@ -841,10 +835,7 @@ mod tests {
     fn rust_loader_serves_embedded_catalog() {
         // Include the gettext metadata header ("") so the charset is declared;
         // originals must stay sorted ("" sorts before "Hello").
-        let mo = make_mo(&[
-            ("", "Content-Type: text/plain; charset=UTF-8\n"),
-            ("Hello", "Bonjour"),
-        ]);
+        let mo = make_mo(&[("", "Content-Type: text/plain; charset=UTF-8\n"), ("Hello", "Bonjour")]);
 
         let translations = Translations::new();
         translations.set_loader(FixtureLoader { mo });

--- a/rust/wxdragon/src/translations.rs
+++ b/rust/wxdragon/src/translations.rs
@@ -25,9 +25,10 @@
 //! ```
 
 use crate::language::Language;
+use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 use wxdragon_sys as ffi;
 
 /// A translations manager for internationalization support.
@@ -168,6 +169,31 @@ impl Translations {
             return false;
         }
         unsafe { ffi::wxd_Translations_AddStdCatalog(self.ptr) }
+    }
+
+    /// Install a custom [`TranslationsLoader`], replacing the default
+    /// file-based loader.
+    ///
+    /// This lets an application supply catalog data from anywhere (e.g. bytes
+    /// embedded in the binary) instead of `.mo` files on disk. wxWidgets uses a
+    /// single loader, so this replaces any previously installed one; ownership
+    /// of `loader` is transferred to wxWidgets, which drops it when the
+    /// translations object is destroyed or another loader is installed.
+    ///
+    /// Call this before [`add_catalog`](Self::add_catalog) /
+    /// [`add_std_catalog`](Self::add_std_catalog): loading a catalog first
+    /// consults [`TranslationsLoader::available_translations`] to pick the best
+    /// language, then calls [`TranslationsLoader::load_catalog`].
+    pub fn set_loader<L: TranslationsLoader + 'static>(&self, loader: L) {
+        if self.ptr.is_null() {
+            return;
+        }
+        // Double-box: `Box<dyn Trait>` is a fat pointer, so box it again to get
+        // a thin `*mut c_void` we can hand across FFI. Freed by `loader_destroy`.
+        let user_data = Box::into_raw(Box::new(Box::new(loader) as Box<dyn TranslationsLoader>)) as *mut c_void;
+        unsafe {
+            ffi::wxd_Translations_SetRustLoader(self.ptr, &LOADER_VTABLE as *const _, user_data)
+        };
     }
 
     /// Check if a catalog for the given domain is loaded.
@@ -394,6 +420,93 @@ impl Drop for Translations {
         }
     }
 }
+
+/// A source of translation catalogs for [`Translations::set_loader`].
+///
+/// Implement this to feed wxWidgets catalog data from somewhere other than
+/// `.mo` files on disk — for example bytes embedded in the binary. wxWidgets
+/// asks the loader for the languages a domain supports before requesting the
+/// catalog bytes for the chosen language.
+pub trait TranslationsLoader {
+    /// Return the raw `.mo` catalog bytes for `(domain, lang)`, or `None` if
+    /// unavailable.
+    ///
+    /// Returns a [`Cow`] so a loader can hand back either borrowed bytes it
+    /// already holds (e.g. `Cow::Borrowed(b)` over `&'static` embedded data —
+    /// zero-copy) or freshly-computed owned bytes (e.g. `Cow::Owned(vec)` after
+    /// decompressing/decrypting). The bytes only need to live until this call
+    /// returns; wxWidgets parses them synchronously and does not retain the
+    /// buffer.
+    fn load_catalog(&self, domain: &str, lang: &str) -> Option<Cow<'_, [u8]>>;
+
+    /// Return the language codes for which `domain` has a catalog. Consulted
+    /// before [`load_catalog`](Self::load_catalog) to pick the best language;
+    /// returning an empty list means the domain resolves to nothing.
+    fn available_translations(&self, domain: &str) -> Vec<String>;
+}
+
+// The `user_data` handed to the C++ trampoline is a `*mut Box<dyn TranslationsLoader>`
+// (a thin pointer to the fat trait-object box). These trampolines recover it and
+// forward to the trait methods.
+
+unsafe extern "C" fn loader_load_catalog(
+    user_data: *mut c_void,
+    domain: *const c_char,
+    lang: *const c_char,
+    sink: *mut c_void,
+    emit: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize)>,
+) -> bool {
+    if user_data.is_null() || domain.is_null() || lang.is_null() {
+        return false;
+    }
+    let Some(emit) = emit else { return false };
+    unsafe {
+        let loader = &**(user_data as *mut Box<dyn TranslationsLoader>);
+        let domain = CStr::from_ptr(domain).to_string_lossy();
+        let lang = CStr::from_ptr(lang).to_string_lossy();
+        match loader.load_catalog(&domain, &lang) {
+            Some(bytes) => {
+                // `bytes` (borrowed or owned) is alive across this call; C++
+                // parses it inside `emit` before we return and drop it.
+                emit(sink, bytes.as_ptr(), bytes.len());
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+unsafe extern "C" fn loader_available(
+    user_data: *mut c_void,
+    domain: *const c_char,
+    out: *mut ffi::wxd_ArrayString_t,
+) {
+    if user_data.is_null() || domain.is_null() || out.is_null() {
+        return;
+    }
+    unsafe {
+        let loader = &**(user_data as *mut Box<dyn TranslationsLoader>);
+        let domain = CStr::from_ptr(domain).to_string_lossy();
+        for lang in loader.available_translations(&domain) {
+            if let Ok(c_lang) = CString::new(lang) {
+                ffi::wxd_ArrayString_Add(out, c_lang.as_ptr());
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn loader_destroy(user_data: *mut c_void) {
+    if user_data.is_null() {
+        return;
+    }
+    drop(unsafe { Box::from_raw(user_data as *mut Box<dyn TranslationsLoader>) });
+}
+
+static LOADER_VTABLE: ffi::wxd_RustTranslationsLoader_vtable = ffi::wxd_RustTranslationsLoader_vtable {
+    load_catalog: Some(loader_load_catalog),
+    available: Some(loader_available),
+    destroy: Some(loader_destroy),
+};
 
 /// Add a catalog lookup path prefix.
 ///
@@ -648,5 +761,112 @@ impl Drop for UILocale {
         if !self.ptr.is_null() {
             unsafe { ffi::wxd_UILocale_Destroy(self.ptr) };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal little-endian gettext `.mo` catalog from `entries`
+    /// (which must be sorted by original string). Enough for wxWidgets to parse
+    /// and look up messages.
+    fn make_mo(entries: &[(&str, &str)]) -> Vec<u8> {
+        let n = entries.len();
+        let header_size = 28usize; // 7 * u32
+        let orig_table = header_size;
+        let trans_table = orig_table + n * 8;
+        let data_start = trans_table + n * 8;
+
+        let mut strings: Vec<u8> = Vec::new();
+        let mut orig_tab: Vec<(usize, usize)> = Vec::new();
+        for (o, _) in entries {
+            let off = data_start + strings.len();
+            orig_tab.push((o.len(), off));
+            strings.extend_from_slice(o.as_bytes());
+            strings.push(0);
+        }
+        let mut trans_tab: Vec<(usize, usize)> = Vec::new();
+        for (_, t) in entries {
+            let off = data_start + strings.len();
+            trans_tab.push((t.len(), off));
+            strings.extend_from_slice(t.as_bytes());
+            strings.push(0);
+        }
+
+        let mut out: Vec<u8> = Vec::new();
+        let mut w = |v: usize| out.extend_from_slice(&(v as u32).to_le_bytes());
+        w(0x950412de); // magic
+        w(0); // revision
+        w(n); // number of strings
+        w(orig_table);
+        w(trans_table);
+        w(0); // hash table size
+        w(0); // hash table offset
+        for (len, off) in orig_tab.iter().chain(trans_tab.iter()) {
+            out.extend_from_slice(&(*len as u32).to_le_bytes());
+            out.extend_from_slice(&(*off as u32).to_le_bytes());
+        }
+        out.extend_from_slice(&strings);
+        out
+    }
+
+    struct FixtureLoader {
+        mo: Vec<u8>,
+    }
+
+    impl TranslationsLoader for FixtureLoader {
+        fn load_catalog(&self, domain: &str, lang: &str) -> Option<Cow<'_, [u8]>> {
+            if domain == "wxdtest" && lang == "fr" {
+                // Return freshly-owned bytes (not a borrow of `self.mo`) so the
+                // test also proves the owned/compute-on-demand path: the Vec is
+                // dropped right after this returns, so it must be consumed
+                // inside the emit call, not after.
+                Some(Cow::Owned(self.mo.clone()))
+            } else {
+                None
+            }
+        }
+
+        fn available_translations(&self, domain: &str) -> Vec<String> {
+            if domain == "wxdtest" {
+                vec!["fr".to_string()]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    #[test]
+    fn rust_loader_serves_embedded_catalog() {
+        // Include the gettext metadata header ("") so the charset is declared;
+        // originals must stay sorted ("" sorts before "Hello").
+        let mo = make_mo(&[
+            ("", "Content-Type: text/plain; charset=UTF-8\n"),
+            ("Hello", "Bonjour"),
+        ]);
+
+        let translations = Translations::new();
+        translations.set_loader(FixtureLoader { mo });
+        translations.set_language_str("fr");
+
+        // The loader's available_translations must flow through so AddCatalog
+        // can select "fr".
+        let avail = translations.get_available_translations("wxdtest");
+        assert!(avail.contains(&"fr".to_string()), "available translations: {avail:?}");
+
+        // Loading the catalog goes through load_catalog -> CreateFromData.
+        assert!(
+            translations.add_catalog("wxdtest"),
+            "add_catalog should load the catalog supplied by the Rust loader"
+        );
+        assert_eq!(
+            translations.get_string("Hello", "wxdtest").as_deref(),
+            Some("Bonjour"),
+            "string should be translated via the embedded catalog"
+        );
+
+        // A domain the loader doesn't serve resolves to nothing.
+        assert!(translations.get_available_translations("other").is_empty());
     }
 }

--- a/rust/wxdragon/src/translations.rs
+++ b/rust/wxdragon/src/translations.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use crate::language::Language;
+use crate::utils::ArrayString;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
@@ -464,8 +465,8 @@ unsafe extern "C" fn loader_load_catalog(
         let lang = CStr::from_ptr(lang).to_string_lossy();
         match loader.load_catalog(&domain, &lang) {
             Some(bytes) => {
-                // `bytes` (borrowed or owned) is alive across this call; C++
-                // parses it inside `emit` before we return and drop it.
+                // `bytes` alive across the call; C++ consumes them inside `emit`
+                // (see the wxd_TranslationsCatalogSink contract).
                 emit(sink, bytes.as_ptr(), bytes.len());
                 true
             }
@@ -481,11 +482,10 @@ unsafe extern "C" fn loader_available(user_data: *mut c_void, domain: *const c_c
     unsafe {
         let loader = &**(user_data as *mut Box<dyn TranslationsLoader>);
         let domain = CStr::from_ptr(domain).to_string_lossy();
-        for lang in loader.available_translations(&domain) {
-            if let Ok(c_lang) = CString::new(lang) {
-                ffi::wxd_ArrayString_Add(out, c_lang.as_ptr());
-            }
-        }
+        // Borrow (non-owning) the C++-owned array and reuse the shared wrapper's
+        // CString + Add loop instead of hand-rolling it.
+        ArrayString::from(out as *const ffi::wxd_ArrayString_t)
+            .add_many(&loader.available_translations(&domain));
     }
 }
 


### PR DESCRIPTION
## What

Adds a way to plug a custom translations catalog loader implemented in Rust, so an application can supply message catalogs from anywhere — e.g. `.mo` bytes embedded in the binary — instead of only loading `.mo` files from disk via the default `wxFileTranslationsLoader`.

## Why

`Translations::add_std_catalog` / `add_catalog` currently rely on wxWidgets' file-based loader: catalogs must exist as `.mo` files in a lookup path at runtime. There was no way to feed catalog data that lives in memory. This makes it possible to ship translations (including wxWidgets' own `wxstd` strings) inside the executable, with no files to install or path to configure.

## How

- **FFI** (`wxd_translations.h`): a `wxd_RustTranslationsLoader_vtable` (`load_catalog` / `available` / `destroy`) plus `wxd_Translations_SetRustLoader`.
- **C++** (`translations.cpp`): `WxdRustTranslationsLoader : wxTranslationsLoader` forwards to the vtable. Catalog bytes are delivered through an `emit` sink and parsed synchronously with `wxMsgCatalog::CreateFromData`, so both borrowed (static/embedded) and freshly-computed owned bytes work with no lifetime hazard. `GetAvailableTranslations` fills a `wxArrayString` via the existing `wxd_ArrayString_Add` convention. `wxTranslations` takes ownership of the loader and the trait object is released via the vtable's `destroy` callback.
- **Rust** (`translations.rs`): a `TranslationsLoader` trait (`load_catalog(&self, domain, lang) -> Option<Cow<[u8]>>`, `available_translations(&self, domain) -> Vec<String>`) and `Translations::set_loader`. Re-exported from the prelude.

## Usage

```rust
use wxdragon::prelude::*;
use std::borrow::Cow;

struct EmbeddedLoader;
impl TranslationsLoader for EmbeddedLoader {
    fn load_catalog(&self, domain: &str, lang: &str) -> Option<Cow<'_, [u8]>> {
        if domain == "wxstd" && lang == "nl" {
            Some(Cow::Borrowed(include_bytes!("../locale/nl/wxstd.mo")))
        } else {
            None
        }
    }
    fn available_translations(&self, domain: &str) -> Vec<String> {
        if domain == "wxstd" { vec!["nl".into()] } else { vec![] }
    }
}

let t = Translations::new();
t.set_loader(EmbeddedLoader);      // replaces the file loader
t.set_language_str("nl");
t.add_std_catalog();               // resolves from embedded bytes
Translations::set_global(t);
```

## Notes

- `SetLoader` replaces the single installed loader (wxWidgets allows one).
- Ordering matters: install the loader before `add_catalog` / `add_std_catalog`, since loading first consults `available_translations` (via `GetBestTranslation`) to pick the language, then calls `load_catalog`.

## Testing

Adds a unit test (`rust_loader_serves_embedded_catalog`) that builds a minimal in-memory `.mo`, installs it via `set_loader`, and asserts both the `available_translations` path (so `add_catalog` selects the language) and the translated lookup work. The fixture returns owned bytes to also cover the compute-on-demand path.
