### PR TITLE
Add NOTEBOOK_PAGE_CHANGING event for Notebook

### DIFF
--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -345,6 +345,7 @@ typedef enum {
     WXD_EVENT_TYPE_GRID_COL_SIZE = 385,             // wxEVT_GRID_COL_SIZE
     WXD_EVENT_TYPE_GRID_RANGE_SELECTED = 386,       // wxEVT_GRID_RANGE_SELECTED
     WXD_EVENT_TYPE_GRID_TABBING = 387,              // wxEVT_GRID_TABBING
+    WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGING = 389,    // wxEVT_NOTEBOOK_PAGE_CHANGING
 
     WXD_EVENT_TYPE_MAX // Keep this last for count if needed, or remove if not used for iteration
 } WXDEventTypeCEnum;

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -1082,6 +1082,8 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
     // Notebook events
     case WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGED:
         return wxEVT_NOTEBOOK_PAGE_CHANGED;
+    case WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGING:
+        return wxEVT_NOTEBOOK_PAGE_CHANGING;
 
     // Splitter events
     case WXD_EVENT_TYPE_SPLITTER_SASH_POS_CHANGED:

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -158,8 +158,9 @@ pub struct EventType: ffi::WXDEventTypeCEnum { // Use the generated C enum type
     const SPIN_UP = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SPIN_UP;
     const SPIN_DOWN = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SPIN_DOWN;
     const SPIN = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SPIN;
-    // ADDED: Notebook event type
+    // ADDED: Notebook event types
     const NOTEBOOK_PAGE_CHANGED = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGED;
+    const NOTEBOOK_PAGE_CHANGING = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGING;
     // ADDED: Splitter event types
     const SPLITTER_SASH_POS_CHANGED = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SPLITTER_SASH_POS_CHANGED;
     const SPLITTER_SASH_POS_CHANGING = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SPLITTER_SASH_POS_CHANGING;

--- a/rust/wxdragon/src/event/notebook_events.rs
+++ b/rust/wxdragon/src/event/notebook_events.rs
@@ -7,6 +7,8 @@ use crate::event::{Event, EventType, WxEvtHandler};
 pub enum NotebookEvent {
     /// A notebook page has been changed.
     PageChanged,
+    /// A notebook page is about to change. This event can be vetoed.
+    PageChanging,
 }
 
 /// Event data for notebook events.
@@ -39,5 +41,6 @@ pub trait NotebookEvents: WxEvtHandler {}
 // Use the macro to implement the trait
 crate::implement_category_event_handlers!(
     NotebookEvents, NotebookEvent, NotebookEventData,
-    PageChanged => page_changed, EventType::NOTEBOOK_PAGE_CHANGED
-); 
+    PageChanged => page_changed, EventType::NOTEBOOK_PAGE_CHANGED,
+    PageChanging => page_changing, EventType::NOTEBOOK_PAGE_CHANGING
+);

--- a/rust/wxdragon/src/widgets/notebook.rs
+++ b/rust/wxdragon/src/widgets/notebook.rs
@@ -302,6 +302,8 @@ widget_builder!(
 pub enum NotebookEvent {
     /// A notebook page has been changed.
     PageChanged,
+    /// A notebook page is about to change. This event can be vetoed.
+    PageChanging,
 }
 
 /// Event data for a `Notebook::PageChanged` event.
@@ -341,7 +343,8 @@ impl NotebookPageChangedEvent {
 // Use the implement_widget_local_event_handlers macro for notebook events
 crate::implement_widget_local_event_handlers!(
     Notebook, NotebookEvent, NotebookPageChangedEvent,
-    PageChanged => page_changed, EventType::NOTEBOOK_PAGE_CHANGED
+    PageChanged => page_changed, EventType::NOTEBOOK_PAGE_CHANGED,
+    PageChanging => page_changing, EventType::NOTEBOOK_PAGE_CHANGING
 );
 
 // XRC Support - enables Notebook to be created from XRC-managed pointers


### PR DESCRIPTION
### Summary

`Notebook` currently only binds `wxEVT_NOTEBOOK_PAGE_CHANGED`, which fires *after* the page switch (and after focus has moved to the new page). This adds the companion `wxEVT_NOTEBOOK_PAGE_CHANGING` event, which fires *before* the switch — mirroring the binding `Treebook` already has.

### Changes

- **wxdragon-sys**: add `WXD_EVENT_TYPE_NOTEBOOK_PAGE_CHANGING` (value `389`) and map it to `wxEVT_NOTEBOOK_PAGE_CHANGING` in the C++ event bridge. The vetable-event check and the reverse `wxEventType → WXD` lookup already handled it, so no further C++ wiring was needed.
- **wxdragon**: add `EventType::NOTEBOOK_PAGE_CHANGING`.
- **wxdragon**: add `NotebookEvent::PageChanging` and an `on_page_changing` handler on both the `Notebook` widget (`implement_widget_local_event_handlers!`) and the `NotebookEvents` category trait (`implement_category_event_handlers!`), reusing the existing event-data type. `get_selection()` returns the page about to be selected; `get_old_selection()` the current one. The event can be vetoed via the base event.

### Notes

- The new enum value is appended (`389`) rather than inserted, to avoid renumbering existing `WXDEventTypeCEnum` values. (`388` was already taken by `ACTIVATE`.)
- Follows the `Treebook` `PageChanging` implementation exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
