### PR TITLE
fix msvc arm64 debug builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,10 @@ jobs:
       - name: Install target ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}
 
-      - name: Build for ${{ matrix.target }}
+      - name: Debug build for ${{ matrix.target }}
+        run: cargo build --features "aui,xrc,richtext,stc,webview" --target ${{ matrix.target }}
+
+      - name: Release build for ${{ matrix.target }}
         run: cargo build --features "aui,xrc,richtext,stc,webview" --target ${{ matrix.target }} --release
 
   build-msys-mingw64:

--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -281,6 +281,9 @@ fn build_wxdragon_wrapper(
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
     let mut is_debug = profile == "debug";
+    // Cargo PROFILE can be "debug" while MSVC CMake builds intentionally use
+    // RelWithDebInfo to avoid debug CRT and wx library suffix mismatches.
+    let mut cmake_profile = profile.clone();
 
     let mut toolchain_file: Option<String> = None;
 
@@ -371,8 +374,10 @@ fn build_wxdragon_wrapper(
             };
 
             let build_type = if is_debug { "Debug" } else { "RelWithDebInfo" };
+            cmake_profile = build_type.to_string();
             cmake_config
                 .generator("Ninja")
+                .profile(build_type)
                 .define("CMAKE_BUILD_TYPE", build_type)
                 .define("CMAKE_MSVC_RUNTIME_LIBRARY", rt_lib)
                 .define("CMAKE_POLICY_DEFAULT_CMP0091", "NEW")
@@ -391,7 +396,6 @@ fn build_wxdragon_wrapper(
             cmake_config
                 .generator(&generator)
                 .define("CMAKE_GENERATOR_PLATFORM", "Win32")
-                .define("--config", &profile)
                 .cxxflag("/EHsc");
         } else if target == "aarch64-pc-windows-msvc" {
             let generator = detect_visual_studio_generator().unwrap_or_else(|| {
@@ -401,7 +405,6 @@ fn build_wxdragon_wrapper(
             cmake_config
                 .generator(&generator)
                 .define("CMAKE_GENERATOR_PLATFORM", "ARM64")
-                .define("--config", &profile)
                 .cxxflag("/EHsc");
         }
     }
@@ -548,8 +551,8 @@ fn build_wxdragon_wrapper(
             println!("cargo:rustc-link-search=native={wx_lib_widgets}");
 
             if target == "i686-pc-windows-msvc" || target == "aarch64-pc-windows-msvc" {
-                // build/lib/Debug or build/lib/Release
-                let sub_dir = format!("build/lib/{profile}");
+                // Visual Studio generators place wrapper archives under the active CMake config.
+                let sub_dir = format!("build/lib/{cmake_profile}");
                 let wx_lib3 = wxdragon_sys_build_dir.join(sub_dir).display().to_string();
                 println!("cargo:rustc-link-search=native={wx_lib3}");
             }


### PR DESCRIPTION
Fixes https://github.com/AllenDang/wxDragon/issues/162

Fixes Windows MSVC debug builds for ARM64/i686 targets by separating Cargo's `PROFILE` from the effective CMake build configuration used for native wxDragon/wxWidgets builds.

For MSVC, the build script intentionally disables debug native builds and uses `RelWithDebInfo` to avoid debug CRT and wx library suffix mismatches. However, ARM64/i686 switch to the Visual Studio generator, which is multi-config. Without setting `cmake::Config::profile`, the `cmake` crate still builds with Cargo's debug profile as `--config Debug`, causing wxWidgets to emit debug-suffixed libraries like `wxmsw33ud_adv.lib` while the Rust link step requests non-debug names like `wxmsw33u_adv`.

This PR makes the effective CMake profile explicit and uses it consistently for:
- the CMake build config via `cmake_config.profile(...)`
- non-debug MSVC wx library naming
- Visual Studio config-specific wrapper link search paths

It also updates Windows cross-target CI to run both debug and release builds for the existing MSVC target matrix.
