### PR TITLE
Link libsdl on linux when enabled in cmake cashe

### DIFF
--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -417,7 +417,6 @@ fn build_wxdragon_wrapper(
     let dst = cmake_config.build();
     let build_dir = dst.join("build");
     let cmake_cache = std::fs::read_to_string(build_dir.join("CMakeCache.txt")).unwrap_or_default();
-    let use_libnotify = cmake_cache.contains("wxUSE_LIBNOTIFY:BOOL=ON");
 
     let default_lib_dir = build_dir.join("lib");
 
@@ -918,9 +917,14 @@ fn build_wxdragon_wrapper(
         println!("cargo:rustc-link-lib=jpeg");
         println!("cargo:rustc-link-lib=expat");
         println!("cargo:rustc-link-lib=tiff");
-        if use_libnotify {
+
+        if cmake_cache.contains("wxUSE_LIBNOTIFY:BOOL=ON") {
             println!("cargo:rustc-link-lib=notify");
         }
+        if cmake_cache.contains("wxUSE_LIBSDL:BOOL=ON") {
+            println!("cargo:rustc-link-lib=SDL2");
+        }
+
         if lib_dirs.iter().any(|dir| dir.join("libwx_gtk3u_propgrid-3.3.a").exists()) {
             println!("cargo:rustc-link-lib=static=wx_gtk3u_propgrid-3.3");
         } else {


### PR DESCRIPTION
## Summary

When wxWidgets is built with `wxUSE_LIBSDL=ON`, the final Cargo link step does not link against SDL2.

This causes release builds on Linux to fail with unresolved `SDL_*` symbols, for example:

```text
undefined symbol: SDL_LockAudio
undefined symbol: SDL_PauseAudio
undefined symbol: SDL_UnlockAudio
```

This PR adds the missing linker flag when enabled in cmake cashe:

```rust
println!("cargo:rustc-link-lib=SDL2");
```

## Notes

I could only reproduce this with release builds. Debug builds complete successfully on my system.

## Tested

- Arch Linux
- `cargo build --release`
- `cargo test --release`