### PR TITLE
Fix aarch64/ARM build: use c_char instead of hardcoded i8 for FFI cha…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,6 @@ jobs:
           cargo clean
           cargo build --package gallery
 
-      - name: Abort on error
-        if: ${{ failure() }}
-        run: echo "Some of jobs failed" && false
-
   windows-cross-build:
     strategy:
       fail-fast: false

--- a/rust/wxdragon/src/data_object.rs
+++ b/rust/wxdragon/src/data_object.rs
@@ -109,7 +109,7 @@ impl TextDataObject {
         if len <= 0 {
             return String::new();
         }
-        let mut buf: Vec<i8> = vec![0; len as usize + 1];
+        let mut buf: Vec<core::ffi::c_char> = vec![0; len as usize + 1];
         unsafe { ffi::wxd_TextDataObject_GetText(ptr, buf.as_mut_ptr(), buf.len()) };
         unsafe { CStr::from_ptr(buf.as_ptr()).to_string_lossy().to_string() }
     }

--- a/rust/wxdragon/src/ipc.rs
+++ b/rust/wxdragon/src/ipc.rs
@@ -137,7 +137,7 @@ impl ConnectionCallbacks {
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn on_execute_trampoline(
     user_data: *mut c_void,
-    topic: *const i8,
+    topic: *const core::ffi::c_char,
     data: *const c_void,
     size: usize,
     format: ffi::wxd_IPCFormat,
@@ -165,8 +165,8 @@ unsafe extern "C" fn on_execute_trampoline(
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn on_request_trampoline(
     user_data: *mut c_void,
-    topic: *const i8,
-    item: *const i8,
+    topic: *const core::ffi::c_char,
+    item: *const core::ffi::c_char,
     out_size: *mut usize,
     format: ffi::wxd_IPCFormat,
 ) -> *const c_void {
@@ -203,8 +203,8 @@ unsafe extern "C" fn on_request_trampoline(
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn on_poke_trampoline(
     user_data: *mut c_void,
-    topic: *const i8,
-    item: *const i8,
+    topic: *const core::ffi::c_char,
+    item: *const core::ffi::c_char,
     data: *const c_void,
     size: usize,
     format: ffi::wxd_IPCFormat,
@@ -235,7 +235,7 @@ unsafe extern "C" fn on_poke_trampoline(
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_start_advise_trampoline(user_data: *mut c_void, topic: *const i8, item: *const i8) -> bool {
+unsafe extern "C" fn on_start_advise_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char, item: *const core::ffi::c_char) -> bool {
     if user_data.is_null() {
         return false;
     }
@@ -257,7 +257,7 @@ unsafe extern "C" fn on_start_advise_trampoline(user_data: *mut c_void, topic: *
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_stop_advise_trampoline(user_data: *mut c_void, topic: *const i8, item: *const i8) -> bool {
+unsafe extern "C" fn on_stop_advise_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char, item: *const core::ffi::c_char) -> bool {
     if user_data.is_null() {
         return false;
     }
@@ -281,8 +281,8 @@ unsafe extern "C" fn on_stop_advise_trampoline(user_data: *mut c_void, topic: *c
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn on_advise_trampoline(
     user_data: *mut c_void,
-    topic: *const i8,
-    item: *const i8,
+    topic: *const core::ffi::c_char,
+    item: *const core::ffi::c_char,
     data: *const c_void,
     size: usize,
     format: ffi::wxd_IPCFormat,
@@ -617,7 +617,7 @@ struct ServerCallbacks {
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_accept_connection_trampoline(user_data: *mut c_void, topic: *const i8) -> *mut ffi::wxd_IPCConnection_t {
+unsafe extern "C" fn on_accept_connection_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char) -> *mut ffi::wxd_IPCConnection_t {
     if user_data.is_null() {
         return ptr::null_mut();
     }

--- a/rust/wxdragon/src/ipc.rs
+++ b/rust/wxdragon/src/ipc.rs
@@ -235,7 +235,11 @@ unsafe extern "C" fn on_poke_trampoline(
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_start_advise_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char, item: *const core::ffi::c_char) -> bool {
+unsafe extern "C" fn on_start_advise_trampoline(
+    user_data: *mut c_void,
+    topic: *const core::ffi::c_char,
+    item: *const core::ffi::c_char,
+) -> bool {
     if user_data.is_null() {
         return false;
     }
@@ -257,7 +261,11 @@ unsafe extern "C" fn on_start_advise_trampoline(user_data: *mut c_void, topic: *
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_stop_advise_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char, item: *const core::ffi::c_char) -> bool {
+unsafe extern "C" fn on_stop_advise_trampoline(
+    user_data: *mut c_void,
+    topic: *const core::ffi::c_char,
+    item: *const core::ffi::c_char,
+) -> bool {
     if user_data.is_null() {
         return false;
     }
@@ -617,7 +625,10 @@ struct ServerCallbacks {
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn on_accept_connection_trampoline(user_data: *mut c_void, topic: *const core::ffi::c_char) -> *mut ffi::wxd_IPCConnection_t {
+unsafe extern "C" fn on_accept_connection_trampoline(
+    user_data: *mut c_void,
+    topic: *const core::ffi::c_char,
+) -> *mut ffi::wxd_IPCConnection_t {
     if user_data.is_null() {
         return ptr::null_mut();
     }

--- a/rust/wxdragon/src/widgets/editable_listbox.rs
+++ b/rust/wxdragon/src/widgets/editable_listbox.rs
@@ -197,7 +197,7 @@ impl EditableListBox {
 
         let c_strings: Vec<CString> = strings.iter().map(|s| CString::new(*s).unwrap_or_default()).collect();
 
-        let mut c_ptrs: Vec<*const i8> = c_strings.iter().map(|s| s.as_ptr()).collect();
+        let mut c_ptrs: Vec<*const core::ffi::c_char> = c_strings.iter().map(|s| s.as_ptr()).collect();
 
         unsafe { ffi::wxd_EditableListBox_SetStrings(ptr, c_ptrs.as_mut_ptr(), c_strings.len() as i32) }
     }

--- a/rust/wxdragon/src/widgets/grid.rs
+++ b/rust/wxdragon/src/widgets/grid.rs
@@ -360,8 +360,16 @@ impl Grid {
                 return String::new();
             }
             let mut buffer = vec![0u8; len as usize + 1];
-            ffi::wxd_Grid_GetCellValue(ptr, row, col, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
+            ffi::wxd_Grid_GetCellValue(
+                ptr,
+                row,
+                col,
+                buffer.as_mut_ptr() as *mut core::ffi::c_char,
+                buffer.len() as i32,
+            );
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char)
+                .to_string_lossy()
+                .into_owned()
         }
     }
 
@@ -390,7 +398,9 @@ impl Grid {
             }
             let mut buffer = vec![0u8; len as usize + 1];
             ffi::wxd_Grid_GetRowLabelValue(ptr, row, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char)
+                .to_string_lossy()
+                .into_owned()
         }
     }
 
@@ -417,7 +427,9 @@ impl Grid {
             }
             let mut buffer = vec![0u8; len as usize + 1];
             ffi::wxd_Grid_GetColLabelValue(ptr, col, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char)
+                .to_string_lossy()
+                .into_owned()
         }
     }
 

--- a/rust/wxdragon/src/widgets/grid.rs
+++ b/rust/wxdragon/src/widgets/grid.rs
@@ -360,8 +360,8 @@ impl Grid {
                 return String::new();
             }
             let mut buffer = vec![0u8; len as usize + 1];
-            ffi::wxd_Grid_GetCellValue(ptr, row, col, buffer.as_mut_ptr() as *mut i8, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const i8).to_string_lossy().into_owned()
+            ffi::wxd_Grid_GetCellValue(ptr, row, col, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
         }
     }
 
@@ -389,8 +389,8 @@ impl Grid {
                 return String::new();
             }
             let mut buffer = vec![0u8; len as usize + 1];
-            ffi::wxd_Grid_GetRowLabelValue(ptr, row, buffer.as_mut_ptr() as *mut i8, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const i8).to_string_lossy().into_owned()
+            ffi::wxd_Grid_GetRowLabelValue(ptr, row, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
         }
     }
 
@@ -416,8 +416,8 @@ impl Grid {
                 return String::new();
             }
             let mut buffer = vec![0u8; len as usize + 1];
-            ffi::wxd_Grid_GetColLabelValue(ptr, col, buffer.as_mut_ptr() as *mut i8, buffer.len() as i32);
-            CStr::from_ptr(buffer.as_ptr() as *const i8).to_string_lossy().into_owned()
+            ffi::wxd_Grid_GetColLabelValue(ptr, col, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer.len() as i32);
+            CStr::from_ptr(buffer.as_ptr() as *const core::ffi::c_char).to_string_lossy().into_owned()
         }
     }
 
@@ -1557,8 +1557,8 @@ impl Grid {
             return String::new();
         }
         let mut buf = vec![0u8; (needed + 1) as usize];
-        unsafe { ffi::wxd_Grid_GetCornerLabelValue(ptr, buf.as_mut_ptr() as *mut i8, buf.len() as i32) };
-        let c_str = unsafe { CStr::from_ptr(buf.as_ptr() as *const i8) };
+        unsafe { ffi::wxd_Grid_GetCornerLabelValue(ptr, buf.as_mut_ptr() as *mut core::ffi::c_char, buf.len() as i32) };
+        let c_str = unsafe { CStr::from_ptr(buf.as_ptr() as *const core::ffi::c_char) };
         c_str.to_string_lossy().into_owned()
     }
 

--- a/rust/wxdragon/src/widgets/list_ctrl.rs
+++ b/rust/wxdragon/src/widgets/list_ctrl.rs
@@ -441,7 +441,7 @@ impl ListCtrl {
                 ptr,
                 index as c_longlong,
                 col,
-                buffer.as_mut_ptr() as *mut i8,
+                buffer.as_mut_ptr() as *mut core::ffi::c_char,
                 needed_len as i32,
             );
             if actual_len <= 0 {

--- a/rust/wxdragon/src/widgets/treebook.rs
+++ b/rust/wxdragon/src/widgets/treebook.rs
@@ -239,7 +239,7 @@ impl Treebook {
             let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
             // Second call to actually get the string
-            let copied_len_with_null = ffi::wxd_Treebook_GetPageText(ptr, n, buffer.as_mut_ptr() as *mut i8, buffer_size as i32);
+            let copied_len_with_null = ffi::wxd_Treebook_GetPageText(ptr, n, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size as i32);
 
             if copied_len_with_null <= 0 {
                 // Check for error on second call

--- a/rust/wxdragon/src/widgets/treebook.rs
+++ b/rust/wxdragon/src/widgets/treebook.rs
@@ -239,7 +239,8 @@ impl Treebook {
             let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
             // Second call to actually get the string
-            let copied_len_with_null = ffi::wxd_Treebook_GetPageText(ptr, n, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size as i32);
+            let copied_len_with_null =
+                ffi::wxd_Treebook_GetPageText(ptr, n, buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size as i32);
 
             if copied_len_with_null <= 0 {
                 // Check for error on second call

--- a/rust/wxdragon/src/widgets/treectrl.rs
+++ b/rust/wxdragon/src/widgets/treectrl.rs
@@ -622,7 +622,9 @@ impl TreeCtrl {
         let mut buffer: Vec<u8> = vec![0; buffer_size];
 
         // Second call to get the actual text
-        let result = unsafe { ffi::wxd_TreeCtrl_GetItemText(ptr, item.as_ptr(), buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size) };
+        let result = unsafe {
+            ffi::wxd_TreeCtrl_GetItemText(ptr, item.as_ptr(), buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size)
+        };
 
         if result < 0 {
             return None;

--- a/rust/wxdragon/src/widgets/treectrl.rs
+++ b/rust/wxdragon/src/widgets/treectrl.rs
@@ -622,7 +622,7 @@ impl TreeCtrl {
         let mut buffer: Vec<u8> = vec![0; buffer_size];
 
         // Second call to get the actual text
-        let result = unsafe { ffi::wxd_TreeCtrl_GetItemText(ptr, item.as_ptr(), buffer.as_mut_ptr() as *mut i8, buffer_size) };
+        let result = unsafe { ffi::wxd_TreeCtrl_GetItemText(ptr, item.as_ptr(), buffer.as_mut_ptr() as *mut core::ffi::c_char, buffer_size) };
 
         if result < 0 {
             return None;


### PR DESCRIPTION
…r pointers

On x86/x86_64 C char is signed (c_char = i8) but on aarch64 it is unsigned (c_char = u8). The wrapper hardcodes *mut i8 / *const i8 for FFI char pointers, so it fails to compile on aarch64 (~40 error[E0308] across grid.rs, treectrl.rs, treebook.rs, list_ctrl.rs, ipc.rs, data_object.rs, editable_listbox.rs).

Replace with core::ffi::c_char (identical to i8 on existing platforms, correct u8 on ARM). wxdragon-sys bindings were already correct; only the wrapper casts needed it. Verified: a full downstream GUI app builds cleanly on Ubuntu 22.04 aarch64 with only this change.