### PR TITLE
feat(statusbar): bind GetFieldRect, SetStatusStyles, SetMinHeight, Ge…

### DIFF
--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_statusbar.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_statusbar.h
@@ -22,4 +22,16 @@ wxd_StatusBar_PushStatusText(wxd_StatusBar_t* self, const char* text, int fieldI
 WXD_EXPORTED void
 wxd_StatusBar_PopStatusText(wxd_StatusBar_t* self, int fieldIndex);
 
+WXD_EXPORTED wxd_Rect
+wxd_StatusBar_GetFieldRect(wxd_StatusBar_t* self, int fieldIndex);
+
+WXD_EXPORTED int
+wxd_StatusBar_GetFieldsCount(wxd_StatusBar_t* self);
+
+WXD_EXPORTED void
+wxd_StatusBar_SetStatusStyles(wxd_StatusBar_t* self, int count, const int* styles);
+
+WXD_EXPORTED void
+wxd_StatusBar_SetMinHeight(wxd_StatusBar_t* self, int height);
+
 #endif // WXD_STATUSBAR_H

--- a/rust/wxdragon-sys/cpp/src/statusbar.cpp
+++ b/rust/wxdragon-sys/cpp/src/statusbar.cpp
@@ -64,6 +64,44 @@ wxd_StatusBar_PopStatusText(wxd_StatusBar_t* self, int fieldIndex)
     }
 }
 
+WXD_EXPORTED wxd_Rect
+wxd_StatusBar_GetFieldRect(wxd_StatusBar_t* self, int fieldIndex)
+{
+    wxd_Rect rect = {0, 0, 0, 0};
+    wxStatusBar* statusBar = (wxStatusBar*)self;
+    if (!statusBar) return rect;
+    wxRect r;
+    if (statusBar->GetFieldRect(fieldIndex, r)) {
+        rect.x = r.x; rect.y = r.y; rect.width = r.width; rect.height = r.height;
+    }
+    return rect;
+}
+
+WXD_EXPORTED int
+wxd_StatusBar_GetFieldsCount(wxd_StatusBar_t* self)
+{
+    wxStatusBar* statusBar = (wxStatusBar*)self;
+    return statusBar ? static_cast<int>(statusBar->GetFieldsCount()) : 0;
+}
+
+WXD_EXPORTED void
+wxd_StatusBar_SetStatusStyles(wxd_StatusBar_t* self, int count, const int* styles)
+{
+    wxStatusBar* statusBar = (wxStatusBar*)self;
+    if (statusBar && count > 0 && styles) {
+        statusBar->SetStatusStyles(count, styles);
+    }
+}
+
+WXD_EXPORTED void
+wxd_StatusBar_SetMinHeight(wxd_StatusBar_t* self, int height)
+{
+    wxStatusBar* statusBar = (wxStatusBar*)self;
+    if (statusBar) {
+        statusBar->SetMinHeight(height);
+    }
+}
+
 // No wxd_StatusBar_Destroy needed, frame manages lifetime when SetStatusBar is called.
 
 } // extern "C"

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -168,7 +168,7 @@ pub use crate::widgets::static_bitmap::{ScaleMode, StaticBitmap, StaticBitmapBui
 pub use crate::widgets::static_line::{StaticLine, StaticLineBuilder, StaticLineStyle};
 pub use crate::widgets::static_text::{StaticText, StaticTextBuilder, StaticTextStyle};
 pub use crate::widgets::staticbox::{StaticBox, StaticBoxBuilder, StaticBoxStyle}; // Added Style
-pub use crate::widgets::statusbar::{StatusBar, StatusBarBuilder};
+pub use crate::widgets::statusbar::{FieldStyle, StatusBar, StatusBarBuilder};
 #[cfg(feature = "stc")]
 pub use crate::widgets::styledtextctrl::{
     EolMode, FindFlags, Lexer, MarginType, MarkerSymbol, SelectionMode, StyledTextCtrl, StyledTextCtrlBuilder,

--- a/rust/wxdragon/src/widgets/mod.rs
+++ b/rust/wxdragon/src/widgets/mod.rs
@@ -166,7 +166,7 @@ pub use static_bitmap::{ScaleMode, StaticBitmap, StaticBitmapBuilder};
 pub use static_line::{StaticLine, StaticLineBuilder, StaticLineStyle};
 pub use static_text::{StaticText, StaticTextBuilder, StaticTextStyle};
 pub use staticbox::{StaticBox, StaticBoxBuilder};
-pub use statusbar::{StatusBar, StatusBarBuilder};
+pub use statusbar::{FieldStyle, StatusBar, StatusBarBuilder};
 #[cfg(feature = "stc")]
 pub use styledtextctrl::{
     EolMode, FindFlags, Lexer, MarginType, MarkerSymbol, SelectionMode, StyledTextCtrl, StyledTextCtrlBuilder,

--- a/rust/wxdragon/src/widgets/statusbar.rs
+++ b/rust/wxdragon/src/widgets/statusbar.rs
@@ -2,7 +2,7 @@
 //! Safe wrapper for wxStatusBar.
 
 use crate::event::WxEvtHandler;
-use crate::geometry::{Point, Size};
+use crate::geometry::{Point, Rect, Size};
 use crate::id::Id;
 use crate::widgets::frame::Frame; // Parent must be a Frame
 use crate::window::{WindowHandle, WxWidget};
@@ -153,6 +153,57 @@ impl StatusBar {
         }
         unsafe { ffi::wxd_StatusBar_PopStatusText(ptr, field_index as c_int) };
     }
+
+    /// The rectangle of a field, in status-bar client coordinates — position a child control over
+    /// a field with it. Zeroed rect for an out-of-range index, or if the status bar was destroyed.
+    pub fn get_field_rect(&self, field_index: usize) -> Rect {
+        let ptr = self.statusbar_ptr();
+        if ptr.is_null() {
+            return Rect::new(0, 0, 0, 0);
+        }
+        let r = unsafe { ffi::wxd_StatusBar_GetFieldRect(ptr, field_index as c_int) };
+        Rect::new(r.x, r.y, r.width, r.height)
+    }
+
+    /// The number of fields. Returns 0 if the status bar has been destroyed.
+    pub fn get_fields_count(&self) -> usize {
+        let ptr = self.statusbar_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_StatusBar_GetFieldsCount(ptr) as usize }
+    }
+
+    /// Sets the per-field border style, one entry per field.
+    /// No-op if the status bar has been destroyed.
+    pub fn set_status_styles(&self, styles: &[FieldStyle]) {
+        let ptr = self.statusbar_ptr();
+        if ptr.is_null() || styles.is_empty() {
+            return;
+        }
+        let raw: Vec<c_int> = styles.iter().map(|s| *s as c_int).collect();
+        unsafe { ffi::wxd_StatusBar_SetStatusStyles(ptr, raw.len() as c_int, raw.as_ptr()) };
+    }
+
+    /// Sets the minimum height of the bar.
+    /// No-op if the status bar has been destroyed.
+    pub fn set_min_height(&self, height: i32) {
+        let ptr = self.statusbar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_StatusBar_SetMinHeight(ptr, height as c_int) };
+    }
+}
+
+/// Per-field border style, for [`StatusBar::set_status_styles`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum FieldStyle {
+    Normal = 0,
+    Flat = 1,
+    Raised = 2,
+    Sunken = 3,
 }
 
 // Manual WxWidget implementation for StatusBar (using WindowHandle)


### PR DESCRIPTION
…tFieldsCount

A wxStatusBar field cannot draw a bitmap, so the wxWidgets way to show an icon or any other control in one is to parent the control to the status bar and position it with GetFieldRect. That was not bound, leaving callers to compute offsets from the bar width and the field widths they had passed in -- which breaks on a font or DPI change, and on platform chrome such as the macOS resize grip.

Adds, following the existing wxd_Grid_CellToRect pattern for returning a wxd_Rect by value:

  StatusBar::get_field_rect(i) -> Rect   (zeroed rect for an invalid index)
  StatusBar::get_fields_count() -> usize
  StatusBar::set_status_styles(&[FieldStyle])
  StatusBar::set_min_height(i32)

FieldStyle is Normal/Flat/Raised/Sunken, matching wxSB_NORMAL/FLAT/RAISED/ SUNKEN (0..3). Flat is what a field reserving space for a control usually wants, so it does not also paint an empty sunken box.