### PR TITLE
Add Sound::from_data for in-memory WAV playback

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_sound.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_sound.h
@@ -19,6 +19,9 @@ typedef enum {
 WXD_EXPORTED wxd_Sound_t*
 wxd_Sound_Create(const char* fileName, bool isResource);
 
+WXD_EXPORTED wxd_Sound_t*
+wxd_Sound_CreateFromData(const unsigned char* data, size_t size);
+
 WXD_EXPORTED void
 wxd_Sound_Destroy(wxd_Sound_t* self);
 

--- a/rust/wxdragon-sys/cpp/src/core/sound.cpp
+++ b/rust/wxdragon-sys/cpp/src/core/sound.cpp
@@ -10,6 +10,12 @@ wxd_Sound_Create(const char* fileName, bool isResource) {
     return (wxd_Sound_t*)sound;
 }
 
+wxd_Sound_t*
+wxd_Sound_CreateFromData(const unsigned char* data, size_t size) {
+    wxSound* sound = new wxSound(size, (const void*)data);
+    return (wxd_Sound_t*)sound;
+}
+
 void
 wxd_Sound_Destroy(wxd_Sound_t* self) {
     if (self) {

--- a/rust/wxdragon/src/sound.rs
+++ b/rust/wxdragon/src/sound.rs
@@ -31,6 +31,13 @@ impl Sound {
         Self { ptr }
     }
 
+    /// Creates a new sound from raw WAV data already in memory, e.g. bytes embedded in
+    /// the binary with `include_bytes!`.
+    pub fn from_data(data: &[u8]) -> Self {
+        let ptr = unsafe { ffi::wxd_Sound_CreateFromData(data.as_ptr(), data.len()) };
+        Self { ptr }
+    }
+
     /// Returns true if the sound was created successfully.
     pub fn is_ok(&self) -> bool {
         if self.ptr.is_null() {


### PR DESCRIPTION
Adds a way to create a Sound directly from bytes already in memory, instead of only from a file path.

wxSound has a size_t/void* constructor on Windows, macOS, and Linux for exactly this, but the C shim only wrapped the file path constructor. This adds wxd_Sound_CreateFromData to the shim and Sound::from_data(data: &[u8]) to the Rust API.

Useful for apps that embed sounds with include_bytes! and want to play them without writing a temp file first.

Tested locally: built wxdragon-sys and wxdragon, then a small test binary that calls Sound::from_data on a real wav file's bytes, checks is_ok(), and calls play(SoundFlags::Sync). Both returned true and the sound played.