### PR TITLE
Expose wxEVT_MAGNIFY and mouse wheel axis

### DIFF
--- a/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
+++ b/rust/wxdragon-sys/cpp/include/events/wxd_event_api.h
@@ -211,6 +211,12 @@ WXD_EXPORTED int
 wxd_MouseEvent_GetWheelRotation(wxd_Event_t* event);
 WXD_EXPORTED int
 wxd_MouseEvent_GetWheelDelta(wxd_Event_t* event);
+WXD_EXPORTED int
+wxd_MouseEvent_GetWheelAxis(wxd_Event_t* event);
+
+// Magnify (pinch-to-zoom) event function
+WXD_EXPORTED float
+wxd_MouseEvent_GetMagnification(wxd_Event_t* event);
 
 // General veto support for all event types (replaces old close event specific functions)
 WXD_EXPORTED bool

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -362,6 +362,7 @@ typedef enum {
     WXD_EVENT_TYPE_PG_COL_BEGIN_DRAG = 401,    // wxEVT_PG_COL_BEGIN_DRAG
     WXD_EVENT_TYPE_PG_COL_DRAGGING = 402,      // wxEVT_PG_COL_DRAGGING
     WXD_EVENT_TYPE_PG_COL_END_DRAG = 403,      // wxEVT_PG_COL_END_DRAG
+    WXD_EVENT_TYPE_MAGNIFY = 404,              // wxEVT_MAGNIFY
 
     WXD_EVENT_TYPE_MAX // Keep this last for count if needed, or remove if not used for iteration
 } WXDEventTypeCEnum;

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -1009,6 +1009,8 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_MOTION;
     case WXD_EVENT_TYPE_MOUSEWHEEL:
         return wxEVT_MOUSEWHEEL;
+    case WXD_EVENT_TYPE_MAGNIFY:
+        return wxEVT_MAGNIFY;
 
     // TaskBarIcon events are handled later in this function (platform-specific support).
     case WXD_EVENT_TYPE_TASKBAR_CLICK:
@@ -1908,6 +1910,32 @@ wxd_MouseEvent_GetWheelDelta(wxd_Event_t* event)
         return 120;
 
     return mouse_event->GetWheelDelta();
+}
+
+WXD_EXPORTED int
+wxd_MouseEvent_GetWheelAxis(wxd_Event_t* event)
+{
+    if (!event)
+        return 0;
+    wxEvent* wx_event = reinterpret_cast<wxEvent*>(event);
+    wxMouseEvent* mouse_event = wxDynamicCast(wx_event, wxMouseEvent);
+    if (!mouse_event)
+        return 0;
+
+    return static_cast<int>(mouse_event->GetWheelAxis());
+}
+
+WXD_EXPORTED float
+wxd_MouseEvent_GetMagnification(wxd_Event_t* event)
+{
+    if (!event)
+        return 0.0f;
+    wxEvent* wx_event = reinterpret_cast<wxEvent*>(event);
+    wxMouseEvent* mouse_event = wxDynamicCast(wx_event, wxMouseEvent);
+    if (!mouse_event)
+        return 0.0f;
+
+    return mouse_event->GetMagnification();
 }
 
 // Modifier key functions for keyboard events

--- a/rust/wxdragon/src/event/event_data.rs
+++ b/rust/wxdragon/src/event/event_data.rs
@@ -62,6 +62,19 @@ impl MouseEventData {
         self.event.get_wheel_delta()
     }
 
+    /// Gets which axis a mouse wheel event occurred on. Vertical is the common case;
+    /// horizontal happens with dedicated horizontal scroll wheels or two-finger trackpad
+    /// panning.
+    pub fn get_wheel_axis(&self) -> crate::event::MouseWheelAxis {
+        self.event.get_wheel_axis()
+    }
+
+    /// Gets the magnification factor for a pinch-to-zoom (magnify) event, e.g. from a
+    /// trackpad. Positive values mean zoom in, negative values mean zoom out.
+    pub fn get_magnification(&self) -> f32 {
+        self.event.get_magnification()
+    }
+
     pub fn skip(&self, skip: bool) {
         self.event.skip(skip);
     }

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -21,8 +21,8 @@ pub mod window_events;
 
 // Re-export window events for easier access
 pub use window_events::{
-    IdleEventData, KeyboardEvent, MouseButtonEvent, MouseEnterEvent, MouseLeaveEvent, MouseMotionEvent, WindowEvent,
-    WindowEventData, WindowEvents, WindowSizeEvent,
+    IdleEventData, KeyboardEvent, MagnifyEvent, MouseButtonEvent, MouseEnterEvent, MouseLeaveEvent, MouseMotionEvent,
+    WindowEvent, WindowEventData, WindowEvents, WindowSizeEvent,
 };
 
 // Re-export button events for easier access
@@ -121,6 +121,7 @@ pub struct EventType: ffi::WXDEventTypeCEnum { // Use the generated C enum type
     const MIDDLE_UP = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MIDDLE_UP;
     const MOTION = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOTION;
     const MOUSEWHEEL = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOUSEWHEEL;
+    const MAGNIFY = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MAGNIFY;
     const ENTER_WINDOW = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_ENTER_WINDOW;
     const LEAVE_WINDOW = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_LEAVE_WINDOW;
     const KEY_DOWN = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_KEY_DOWN;
@@ -547,6 +548,24 @@ impl IdleEvent {
     }
 }
 
+/// Which axis a mouse wheel event occurred on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseWheelAxis {
+    /// Regular up/down scroll wheel. The common case.
+    Vertical,
+    /// Horizontal scroll wheel, or a two-finger horizontal swipe on a trackpad.
+    Horizontal,
+}
+
+impl MouseWheelAxis {
+    fn from_raw(raw: i32) -> Self {
+        match raw {
+            1 => MouseWheelAxis::Horizontal,
+            _ => MouseWheelAxis::Vertical,
+        }
+    }
+}
+
 // --- Simple Event Struct ---
 
 /// Represents a wxWidgets event.
@@ -674,6 +693,25 @@ impl Event {
             return 120; // Default wheel delta
         }
         unsafe { ffi::wxd_MouseEvent_GetWheelDelta(self.0) }
+    }
+
+    /// Gets which axis a mouse wheel event occurred on. Vertical is the common case;
+    /// horizontal happens with dedicated horizontal scroll wheels or two-finger trackpad
+    /// panning.
+    pub fn get_wheel_axis(&self) -> MouseWheelAxis {
+        if self.0.is_null() {
+            return MouseWheelAxis::Vertical;
+        }
+        MouseWheelAxis::from_raw(unsafe { ffi::wxd_MouseEvent_GetWheelAxis(self.0) })
+    }
+
+    /// Gets the magnification factor for a pinch-to-zoom (magnify) event, e.g. from a
+    /// trackpad. Positive values mean zoom in, negative values mean zoom out.
+    pub fn get_magnification(&self) -> f32 {
+        if self.0.is_null() {
+            return 0.0;
+        }
+        unsafe { ffi::wxd_MouseEvent_GetMagnification(self.0) }
     }
 
     /// Gets the key code associated with a key event.

--- a/rust/wxdragon/src/event/window_events.rs
+++ b/rust/wxdragon/src/event/window_events.rs
@@ -18,6 +18,7 @@ pub enum WindowEvent {
     MiddleUp,
     Motion,
     MouseWheel,
+    Magnify,
     EnterWindow,
     LeaveWindow,
 
@@ -48,6 +49,7 @@ pub enum WindowEventData {
     MouseMotion(MouseMotionEvent),
     MouseEnter(MouseEnterEvent),
     MouseLeave(MouseLeaveEvent),
+    Magnify(MagnifyEvent),
     Keyboard(KeyboardEvent),
     Size(WindowSizeEvent),
     Idle(IdleEventData),
@@ -87,6 +89,8 @@ impl WindowEventData {
                 return WindowEventData::MouseEnter(MouseEnterEvent::new(event));
             } else if event_type == EventType::LEAVE_WINDOW {
                 return WindowEventData::MouseLeave(MouseLeaveEvent::new(event));
+            } else if event_type == EventType::MAGNIFY {
+                return WindowEventData::Magnify(MagnifyEvent::new(event));
             } else if event_type == EventType::IDLE {
                 return WindowEventData::Idle(IdleEventData::new(event));
             } else if event_type == EventType::ACTIVATE {
@@ -105,6 +109,7 @@ impl WindowEventData {
             WindowEventData::MouseMotion(event) => event.event.skip(skip),
             WindowEventData::MouseEnter(event) => event.event.skip(skip),
             WindowEventData::MouseLeave(event) => event.event.skip(skip),
+            WindowEventData::Magnify(event) => event.event.skip(skip),
             WindowEventData::Keyboard(event) => event.event.skip(skip),
             WindowEventData::Size(event) => event.event.skip(skip),
             WindowEventData::Idle(event) => event.event.skip(skip),
@@ -183,6 +188,29 @@ impl MouseLeaveEvent {
 
     pub fn get_position(&self) -> Option<crate::geometry::Point> {
         self.event.get_position()
+    }
+}
+
+/// Pinch-to-zoom (magnify) events, e.g. from a trackpad gesture.
+#[derive(Debug)]
+pub struct MagnifyEvent {
+    pub event: MouseEventData,
+}
+
+impl MagnifyEvent {
+    pub fn new(event: Event) -> Self {
+        Self {
+            event: MouseEventData::new(event),
+        }
+    }
+
+    pub fn get_position(&self) -> Option<crate::geometry::Point> {
+        self.event.get_position()
+    }
+
+    /// The magnification factor. Positive means zoom in, negative means zoom out.
+    pub fn get_magnification(&self) -> f32 {
+        self.event.get_magnification()
     }
 }
 
@@ -314,6 +342,7 @@ crate::implement_category_event_handlers!(
     MiddleUp => mouse_middle_up, EventType::MIDDLE_UP,
     Motion => mouse_motion, EventType::MOTION,
     MouseWheel => mouse_wheel, EventType::MOUSEWHEEL,
+    Magnify => magnify, EventType::MAGNIFY,
     EnterWindow => mouse_enter, EventType::ENTER_WINDOW,
     LeaveWindow => mouse_leave, EventType::LEAVE_WINDOW,
     KeyDown => key_down, EventType::KEY_DOWN,

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::color::{Colour, colours};
 pub use crate::config::{Config, ConfigEntryType, ConfigPathGuard, ConfigStyle};
 pub use crate::cursor::{BitmapType, BusyCursor, Cursor, StockCursor, begin_busy_cursor, end_busy_cursor, is_busy, set_cursor};
 pub use crate::datetime::DateTime;
-pub use crate::event::{Event, EventType, IdleEvent, IdleMode, WindowEventData, WxEvtHandler};
+pub use crate::event::{Event, EventType, IdleEvent, IdleMode, MouseWheelAxis, WindowEventData, WxEvtHandler};
 // ADDED: Event category traits
 pub use crate::event::{AppEvents, ButtonEvents, MenuEvents, ScrollEvents, TextEvents, TreeEvents, WindowEvents};
 // ADDED: Event Data Structs


### PR DESCRIPTION
Fixes #157

Adds two things requested in that issue:

1. wxEVT_MAGNIFY, for pinch-to-zoom gestures on a trackpad. New EventType::MAGNIFY, a WindowEvents::on_magnify handler, and a MagnifyEvent with get_magnification() (matches wxMouseEvent::GetMagnification, positive is zoom in, negative is zoom out).

2. wxMouseEvent::GetWheelAxis, so horizontal scroll wheel or two-finger horizontal trackpad panning can be told apart from regular vertical scrolling. New MouseWheelAxis enum (Vertical/Horizontal) and MouseEventData::get_wheel_axis(), usable from the existing on_mouse_wheel handler.

Both values come straight off the existing wxMouseEvent object, same as GetWheelRotation/GetWheelDelta already do, so no new C++ classes or event data structs beyond MagnifyEvent were needed.

Tested locally: built wxdragon-sys and wxdragon clean, then ran a small test app that binds on_magnify and on_mouse_wheel on a frame and calls get_magnification()/get_wheel_axis() in the handlers. It builds, links, and runs without crashing.