### PR TITLE
Add MessageDialog custom button labels

### DIFF
--- a/rust/wxdragon-sys/cpp/include/dialogs/wxd_dialogs.h
+++ b/rust/wxdragon-sys/cpp/include/dialogs/wxd_dialogs.h
@@ -45,6 +45,12 @@ WXD_EXPORTED wxd_MessageDialog_t*
 wxd_MessageDialog_Create(wxd_Window_t* parent, const char* message, const char* caption,
                          wxd_Style_t style);
 
+WXD_EXPORTED void
+wxd_MessageDialog_SetYesNoLabels(wxd_MessageDialog_t* self, const char* yes, const char* no);
+
+WXD_EXPORTED void
+wxd_MessageDialog_SetOKCancelLabels(wxd_MessageDialog_t* self, const char* ok, const char* cancel);
+
 // --- FileDialog ---
 
 WXD_EXPORTED wxd_FileDialog_t*

--- a/rust/wxdragon-sys/cpp/src/message_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/message_dialog.cpp
@@ -22,6 +22,22 @@ wxd_MessageDialog_Create(wxd_Window_t* parent, const char* message, const char* 
     return (wxd_MessageDialog*)dlg;
 }
 
+void
+wxd_MessageDialog_SetYesNoLabels(wxd_MessageDialog_t* self, const char* yes, const char* no)
+{
+    wxMessageDialog* dlg = (wxMessageDialog*)self;
+    if (!dlg) return;
+    dlg->SetYesNoLabels(wxString::FromUTF8(yes ? yes : ""), wxString::FromUTF8(no ? no : ""));
+}
+
+void
+wxd_MessageDialog_SetOKCancelLabels(wxd_MessageDialog_t* self, const char* ok, const char* cancel)
+{
+    wxMessageDialog* dlg = (wxMessageDialog*)self;
+    if (!dlg) return;
+    dlg->SetOKCancelLabels(wxString::FromUTF8(ok ? ok : ""), wxString::FromUTF8(cancel ? cancel : ""));
+}
+
 // ShowModal is handled by wxd_Dialog_ShowModal((wxd_Dialog*)dlg_ptr)
 // Destroy is handled by wxd_Window_Destroy((wxd_Window_t*)dlg_ptr)
 

--- a/rust/wxdragon/src/dialogs/message_dialog.rs
+++ b/rust/wxdragon/src/dialogs/message_dialog.rs
@@ -55,6 +55,27 @@ impl MessageDialog {
         self.dialog_base.show_modal()
     }
 
+    /// Overrides the default labels of the "Yes" and "No" buttons. Must be called
+    /// before `show_modal()`. Only takes effect if the dialog was created with the
+    /// `YesNo` style.
+    pub fn set_yes_no_labels(&self, yes: &str, no: &str) {
+        let c_yes = CString::new(yes).expect("CString::new failed for yes label");
+        let c_no = CString::new(no).expect("CString::new failed for no label");
+        unsafe {
+            ffi::wxd_MessageDialog_SetYesNoLabels(self.as_ptr(), c_yes.as_ptr(), c_no.as_ptr());
+        }
+    }
+
+    /// Overrides the default labels of the "OK" and "Cancel" buttons. Must be called
+    /// before `show_modal()`.
+    pub fn set_ok_cancel_labels(&self, ok: &str, cancel: &str) {
+        let c_ok = CString::new(ok).expect("CString::new failed for ok label");
+        let c_cancel = CString::new(cancel).expect("CString::new failed for cancel label");
+        unsafe {
+            ffi::wxd_MessageDialog_SetOKCancelLabels(self.as_ptr(), c_ok.as_ptr(), c_cancel.as_ptr());
+        }
+    }
+
     pub fn as_ptr(&self) -> MessageDialogPtr {
         self.dialog_base.as_ptr() as MessageDialogPtr
     }


### PR DESCRIPTION
Exposes wxWidgets' SetYesNoLabels() and SetOKCancelLabels() on MessageDialog, so the Yes/No/OK/Cancel button text can be customized instead of using the platform defaults.

Adds `wxd_MessageDialog_SetYesNoLabels`/`wxd_MessageDialog_SetOKCancelLabels` to the C shim, and `set_yes_no_labels`/`set_ok_cancel_labels` methods on the Rust `MessageDialog`. Call them on the built dialog before `show_modal()`.

Fixes #156