### PR TITLE
Add StandardPaths wrapper

### DIFF
--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -226,6 +226,7 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_sysopt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_stdpaths.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_logging.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/wxd_variant.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/misc.cpp

--- a/rust/wxdragon-sys/cpp/include/wxd_stdpaths.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_stdpaths.h
@@ -1,0 +1,38 @@
+#ifndef WXD_STDPATHS_H
+#define WXD_STDPATHS_H 1
+
+#include "wxd_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetExecutablePath(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetConfigDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserConfigDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetDataDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserDataDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserLocalDataDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetDocumentsDir(char* buffer, size_t buffer_len);
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetTempDir(char* buffer, size_t buffer_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_STDPATHS_H

--- a/rust/wxdragon-sys/cpp/include/wxdragon.h
+++ b/rust/wxdragon-sys/cpp/include/wxdragon.h
@@ -6,6 +6,7 @@
 #include "array_string.h"  // ArrayString helper functions
 #include "core/wxd_item.h" // Added for wxd_DataViewItem_t and its functions
 #include "wxd_sysopt.h"
+#include "wxd_stdpaths.h" // wxStandardPaths bindings
 #include "wxd_logging.h" // Logging functions
 #include "wxd_variant.h" // Variant type and functions
 

--- a/rust/wxdragon-sys/cpp/src/wxd_stdpaths.cpp
+++ b/rust/wxdragon-sys/cpp/src/wxd_stdpaths.cpp
@@ -1,0 +1,67 @@
+#include "wx/wxprec.h"
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include "../include/wxdragon.h"
+#include "wxd_utils.h"
+
+#include "wx/stdpaths.h"
+
+extern "C" {
+WXD_EXPORTED int
+wxd_StandardPaths_GetExecutablePath(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetExecutablePath();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetConfigDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetConfigDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserConfigDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetUserConfigDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetDataDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetDataDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserDataDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetUserDataDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetUserLocalDataDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetUserLocalDataDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetDocumentsDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetDocumentsDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+
+WXD_EXPORTED int
+wxd_StandardPaths_GetTempDir(char* buffer, size_t buffer_len)
+{
+    wxString path = wxStandardPaths::Get().GetTempDir();
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(path, buffer, buffer_len);
+}
+}

--- a/rust/wxdragon/src/lib.rs
+++ b/rust/wxdragon/src/lib.rs
@@ -34,6 +34,7 @@ pub mod scrollable;
 pub mod single_instance_checker;
 pub mod sizers;
 pub mod sound;
+pub mod standard_paths;
 pub mod sysopt;
 pub mod timer;
 pub mod translations;

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -22,6 +22,7 @@ pub use crate::id::{ID_ANY, ID_APPLY, ID_CANCEL, ID_HELP, ID_HIGHEST, ID_NO, ID_
 pub use crate::language::Language;
 pub use crate::sizers::WxSizer;
 pub use crate::sound::{Sound, SoundFlags};
+pub use crate::standard_paths::StandardPaths;
 pub use crate::sysopt::SystemOptions;
 pub use crate::types::Style;
 pub use crate::utils::{ArrayString, BrowserLaunchFlags, bell, launch_default_browser};

--- a/rust/wxdragon/src/standard_paths.rs
+++ b/rust/wxdragon/src/standard_paths.rs
@@ -16,7 +16,11 @@ fn call_getter(getter: GetterFn) -> String {
     }
     let mut buffer = vec![0u8; len as usize + 1];
     unsafe { getter(buffer.as_mut_ptr() as *mut std::os::raw::c_char, buffer.len()) };
-    unsafe { CStr::from_ptr(buffer.as_ptr() as *const std::os::raw::c_char).to_string_lossy().to_string() }
+    unsafe {
+        CStr::from_ptr(buffer.as_ptr() as *const std::os::raw::c_char)
+            .to_string_lossy()
+            .to_string()
+    }
 }
 
 impl StandardPaths {

--- a/rust/wxdragon/src/standard_paths.rs
+++ b/rust/wxdragon/src/standard_paths.rs
@@ -1,0 +1,64 @@
+//! Access to standard, platform-appropriate filesystem locations (config, data, documents, etc).
+
+use std::ffi::CStr;
+use wxdragon_sys as ffi;
+
+/// Provides access to standard, platform-appropriate filesystem locations such as the
+/// user's config directory, data directory, and documents folder.
+pub struct StandardPaths;
+
+type GetterFn = unsafe extern "C" fn(*mut std::os::raw::c_char, usize) -> i32;
+
+fn call_getter(getter: GetterFn) -> String {
+    let len = unsafe { getter(std::ptr::null_mut(), 0) };
+    if len <= 0 {
+        return String::new();
+    }
+    let mut buffer = vec![0u8; len as usize + 1];
+    unsafe { getter(buffer.as_mut_ptr() as *mut std::os::raw::c_char, buffer.len()) };
+    unsafe { CStr::from_ptr(buffer.as_ptr() as *const std::os::raw::c_char).to_string_lossy().to_string() }
+}
+
+impl StandardPaths {
+    /// Returns the full path to the running executable.
+    pub fn executable_path() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetExecutablePath)
+    }
+
+    /// Returns the directory for application-wide read-only config files.
+    pub fn config_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetConfigDir)
+    }
+
+    /// Returns the directory for this user's config files for the application.
+    pub fn user_config_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetUserConfigDir)
+    }
+
+    /// Returns the directory for application-wide read-only data files.
+    pub fn data_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetDataDir)
+    }
+
+    /// Returns the directory for this user's data files for the application
+    /// (the right place to store things like a database or cache).
+    pub fn user_data_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetUserDataDir)
+    }
+
+    /// Returns the directory for this user's local (non-roaming) data files for the
+    /// application. Same as [`user_data_dir`](Self::user_data_dir) except on Windows.
+    pub fn user_local_data_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetUserLocalDataDir)
+    }
+
+    /// Returns the directory containing the current user's documents.
+    pub fn documents_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetDocumentsDir)
+    }
+
+    /// Returns a directory suitable for storing temporary files.
+    pub fn temp_dir() -> String {
+        call_getter(ffi::wxd_StandardPaths_GetTempDir)
+    }
+}


### PR DESCRIPTION
Wraps wxStandardPaths for platform-appropriate filesystem locations: executable path, config/data dirs (app-wide and per-user), documents dir, temp dir.