### PR TITLE
Add SystemSettings wrapper for native colours, fonts, and metrics

### DIFF
--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -210,6 +210,7 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/static_text.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/staticbox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/statusbar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/syssettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/taskbar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/text_entry_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/textctrl.cpp

--- a/rust/wxdragon-sys/cpp/include/core/wxd_syssettings.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_syssettings.h
@@ -1,0 +1,28 @@
+#ifndef WXD_SYSSETTINGS_H
+#define WXD_SYSSETTINGS_H
+
+#include "../wxd_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Gets a standard system colour (e.g. the native window background or highlight colour).
+WXD_EXPORTED wxd_Colour_t
+wxd_SystemSettings_GetColour(wxd_SystemColour index);
+
+// Gets a standard system font. Returns a newly allocated wxd_Font_t* owned by the caller,
+// or NULL if the returned font is not valid.
+WXD_EXPORTED wxd_Font_t*
+wxd_SystemSettings_GetFont(wxd_SystemFont index);
+
+// Gets a system-dependent metric, optionally scaled for the display that `win` is on.
+// Pass NULL for `win` to use the default display.
+WXD_EXPORTED int
+wxd_SystemSettings_GetMetric(wxd_SystemMetric index, wxd_Window_t* win);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_SYSSETTINGS_H

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -753,4 +753,108 @@ typedef bool (*wxd_Printout_OnPrintPage_Callback)(void* userData, int pageNum);
 typedef bool (*wxd_Printout_HasPage_Callback)(void* userData, int pageNum);
 typedef void (*wxd_Printout_GetPageInfo_Callback)(void* userData, int* minPage, int* maxPage, int* pageFrom, int* pageTo);
 
+// --- System Settings (wxSystemSettings) ---
+
+// Mirrors wxSystemColour. Values are wxd-internal and mapped explicitly to
+// the corresponding wxSystemColour enumerator in syssettings.cpp, so they do
+// not need to track wxWidgets' own (platform-sensitive) numbering.
+typedef enum {
+    WXD_SYS_COLOUR_SCROLLBAR = 0,
+    WXD_SYS_COLOUR_DESKTOP,
+    WXD_SYS_COLOUR_ACTIVECAPTION,
+    WXD_SYS_COLOUR_INACTIVECAPTION,
+    WXD_SYS_COLOUR_MENU,
+    WXD_SYS_COLOUR_WINDOW,
+    WXD_SYS_COLOUR_WINDOWFRAME,
+    WXD_SYS_COLOUR_MENUTEXT,
+    WXD_SYS_COLOUR_WINDOWTEXT,
+    WXD_SYS_COLOUR_CAPTIONTEXT,
+    WXD_SYS_COLOUR_ACTIVEBORDER,
+    WXD_SYS_COLOUR_INACTIVEBORDER,
+    WXD_SYS_COLOUR_APPWORKSPACE,
+    WXD_SYS_COLOUR_HIGHLIGHT,
+    WXD_SYS_COLOUR_HIGHLIGHTTEXT,
+    WXD_SYS_COLOUR_BTNFACE,
+    WXD_SYS_COLOUR_BTNSHADOW,
+    WXD_SYS_COLOUR_GRAYTEXT,
+    WXD_SYS_COLOUR_BTNTEXT,
+    WXD_SYS_COLOUR_INACTIVECAPTIONTEXT,
+    WXD_SYS_COLOUR_BTNHIGHLIGHT,
+    WXD_SYS_COLOUR_3DDKSHADOW,
+    WXD_SYS_COLOUR_3DLIGHT,
+    WXD_SYS_COLOUR_INFOTEXT,
+    WXD_SYS_COLOUR_INFOBK,
+    WXD_SYS_COLOUR_LISTBOX,
+    WXD_SYS_COLOUR_HOTLIGHT,
+    WXD_SYS_COLOUR_GRADIENTACTIVECAPTION,
+    WXD_SYS_COLOUR_GRADIENTINACTIVECAPTION,
+    WXD_SYS_COLOUR_MENUHILIGHT,
+    WXD_SYS_COLOUR_MENUBAR,
+    WXD_SYS_COLOUR_LISTBOXTEXT,
+    WXD_SYS_COLOUR_LISTBOXHIGHLIGHTTEXT,
+    WXD_SYS_COLOUR_GRIDLINES,
+    WXD_SYS_COLOUR_LISTBOXHIGHLIGHT
+} wxd_SystemColour;
+
+// Mirrors the subset of wxSystemFont that identifies an actual usable font
+// (skips wxSYS_DEFAULT_PALETTE, which isn't a font, and wxSYS_ICONTITLE_FONT,
+// which is a pure synonym of wxSYS_DEFAULT_GUI_FONT).
+typedef enum {
+    WXD_SYS_OEM_FIXED_FONT = 0,
+    WXD_SYS_ANSI_FIXED_FONT,
+    WXD_SYS_ANSI_VAR_FONT,
+    WXD_SYS_SYSTEM_FONT,
+    WXD_SYS_DEVICE_DEFAULT_FONT,
+    WXD_SYS_SYSTEM_FIXED_FONT,
+    WXD_SYS_DEFAULT_GUI_FONT
+} wxd_SystemFont;
+
+// Mirrors wxSystemMetric (wxSYS_CURSOR_X / wxSYS_CURSOR_Y are omitted in
+// favour of wxSYS_CURSOR_SIZE, which wxWidgets documents as their replacement
+// since cursors are always square).
+typedef enum {
+    WXD_SYS_MOUSE_BUTTONS = 0,
+    WXD_SYS_BORDER_X,
+    WXD_SYS_BORDER_Y,
+    WXD_SYS_CURSOR_SIZE,
+    WXD_SYS_DCLICK_X,
+    WXD_SYS_DCLICK_Y,
+    WXD_SYS_DRAG_X,
+    WXD_SYS_DRAG_Y,
+    WXD_SYS_EDGE_X,
+    WXD_SYS_EDGE_Y,
+    WXD_SYS_HSCROLL_ARROW_X,
+    WXD_SYS_HSCROLL_ARROW_Y,
+    WXD_SYS_HTHUMB_X,
+    WXD_SYS_ICON_X,
+    WXD_SYS_ICON_Y,
+    WXD_SYS_ICONSPACING_X,
+    WXD_SYS_ICONSPACING_Y,
+    WXD_SYS_WINDOWMIN_X,
+    WXD_SYS_WINDOWMIN_Y,
+    WXD_SYS_SCREEN_X,
+    WXD_SYS_SCREEN_Y,
+    WXD_SYS_FRAMESIZE_X,
+    WXD_SYS_FRAMESIZE_Y,
+    WXD_SYS_SMALLICON_X,
+    WXD_SYS_SMALLICON_Y,
+    WXD_SYS_HSCROLL_Y,
+    WXD_SYS_VSCROLL_X,
+    WXD_SYS_VSCROLL_ARROW_X,
+    WXD_SYS_VSCROLL_ARROW_Y,
+    WXD_SYS_VTHUMB_Y,
+    WXD_SYS_CAPTION_Y,
+    WXD_SYS_MENU_Y,
+    WXD_SYS_NETWORK_PRESENT,
+    WXD_SYS_PENWINDOWS_PRESENT,
+    WXD_SYS_SHOW_SOUNDS,
+    WXD_SYS_SWAP_BUTTONS,
+    WXD_SYS_DCLICK_MSEC,
+    WXD_SYS_CARET_ON_MSEC,
+    WXD_SYS_CARET_OFF_MSEC,
+    WXD_SYS_CARET_TIMEOUT_MSEC
+} wxd_SystemMetric;
+
+// --- End of System Settings ---
+
 #endif // WXD_TYPES_H

--- a/rust/wxdragon-sys/cpp/include/wxdragon.h
+++ b/rust/wxdragon-sys/cpp/include/wxdragon.h
@@ -159,6 +159,7 @@ extern "C" {
 #include "core/wxd_uiactionsimulator.h"
 #include "core/wxd_config.h"
 #include "core/wxd_misc.h"
+#include "core/wxd_syssettings.h"
 
 #ifdef __cplusplus
 } // extern "C"

--- a/rust/wxdragon-sys/cpp/src/syssettings.cpp
+++ b/rust/wxdragon-sys/cpp/src/syssettings.cpp
@@ -1,0 +1,223 @@
+#include <wx/wxprec.h>
+#include <wx/wx.h>
+#include "../include/wxdragon.h"
+#include <wx/settings.h>
+
+namespace {
+
+wxSystemColour
+map_system_colour(wxd_SystemColour index)
+{
+    switch (index) {
+    case WXD_SYS_COLOUR_SCROLLBAR:
+        return wxSYS_COLOUR_SCROLLBAR;
+    case WXD_SYS_COLOUR_DESKTOP:
+        return wxSYS_COLOUR_DESKTOP;
+    case WXD_SYS_COLOUR_ACTIVECAPTION:
+        return wxSYS_COLOUR_ACTIVECAPTION;
+    case WXD_SYS_COLOUR_INACTIVECAPTION:
+        return wxSYS_COLOUR_INACTIVECAPTION;
+    case WXD_SYS_COLOUR_MENU:
+        return wxSYS_COLOUR_MENU;
+    case WXD_SYS_COLOUR_WINDOW:
+        return wxSYS_COLOUR_WINDOW;
+    case WXD_SYS_COLOUR_WINDOWFRAME:
+        return wxSYS_COLOUR_WINDOWFRAME;
+    case WXD_SYS_COLOUR_MENUTEXT:
+        return wxSYS_COLOUR_MENUTEXT;
+    case WXD_SYS_COLOUR_WINDOWTEXT:
+        return wxSYS_COLOUR_WINDOWTEXT;
+    case WXD_SYS_COLOUR_CAPTIONTEXT:
+        return wxSYS_COLOUR_CAPTIONTEXT;
+    case WXD_SYS_COLOUR_ACTIVEBORDER:
+        return wxSYS_COLOUR_ACTIVEBORDER;
+    case WXD_SYS_COLOUR_INACTIVEBORDER:
+        return wxSYS_COLOUR_INACTIVEBORDER;
+    case WXD_SYS_COLOUR_APPWORKSPACE:
+        return wxSYS_COLOUR_APPWORKSPACE;
+    case WXD_SYS_COLOUR_HIGHLIGHT:
+        return wxSYS_COLOUR_HIGHLIGHT;
+    case WXD_SYS_COLOUR_HIGHLIGHTTEXT:
+        return wxSYS_COLOUR_HIGHLIGHTTEXT;
+    case WXD_SYS_COLOUR_BTNFACE:
+        return wxSYS_COLOUR_BTNFACE;
+    case WXD_SYS_COLOUR_BTNSHADOW:
+        return wxSYS_COLOUR_BTNSHADOW;
+    case WXD_SYS_COLOUR_GRAYTEXT:
+        return wxSYS_COLOUR_GRAYTEXT;
+    case WXD_SYS_COLOUR_BTNTEXT:
+        return wxSYS_COLOUR_BTNTEXT;
+    case WXD_SYS_COLOUR_INACTIVECAPTIONTEXT:
+        return wxSYS_COLOUR_INACTIVECAPTIONTEXT;
+    case WXD_SYS_COLOUR_BTNHIGHLIGHT:
+        return wxSYS_COLOUR_BTNHIGHLIGHT;
+    case WXD_SYS_COLOUR_3DDKSHADOW:
+        return wxSYS_COLOUR_3DDKSHADOW;
+    case WXD_SYS_COLOUR_3DLIGHT:
+        return wxSYS_COLOUR_3DLIGHT;
+    case WXD_SYS_COLOUR_INFOTEXT:
+        return wxSYS_COLOUR_INFOTEXT;
+    case WXD_SYS_COLOUR_INFOBK:
+        return wxSYS_COLOUR_INFOBK;
+    case WXD_SYS_COLOUR_LISTBOX:
+        return wxSYS_COLOUR_LISTBOX;
+    case WXD_SYS_COLOUR_HOTLIGHT:
+        return wxSYS_COLOUR_HOTLIGHT;
+    case WXD_SYS_COLOUR_GRADIENTACTIVECAPTION:
+        return wxSYS_COLOUR_GRADIENTACTIVECAPTION;
+    case WXD_SYS_COLOUR_GRADIENTINACTIVECAPTION:
+        return wxSYS_COLOUR_GRADIENTINACTIVECAPTION;
+    case WXD_SYS_COLOUR_MENUHILIGHT:
+        return wxSYS_COLOUR_MENUHILIGHT;
+    case WXD_SYS_COLOUR_MENUBAR:
+        return wxSYS_COLOUR_MENUBAR;
+    case WXD_SYS_COLOUR_LISTBOXTEXT:
+        return wxSYS_COLOUR_LISTBOXTEXT;
+    case WXD_SYS_COLOUR_LISTBOXHIGHLIGHTTEXT:
+        return wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT;
+    case WXD_SYS_COLOUR_GRIDLINES:
+        return wxSYS_COLOUR_GRIDLINES;
+    case WXD_SYS_COLOUR_LISTBOXHIGHLIGHT:
+        return wxSYS_COLOUR_LISTBOXHIGHLIGHT;
+    }
+    return wxSYS_COLOUR_WINDOW;
+}
+
+wxSystemFont
+map_system_font(wxd_SystemFont index)
+{
+    switch (index) {
+    case WXD_SYS_OEM_FIXED_FONT:
+        return wxSYS_OEM_FIXED_FONT;
+    case WXD_SYS_ANSI_FIXED_FONT:
+        return wxSYS_ANSI_FIXED_FONT;
+    case WXD_SYS_ANSI_VAR_FONT:
+        return wxSYS_ANSI_VAR_FONT;
+    case WXD_SYS_SYSTEM_FONT:
+        return wxSYS_SYSTEM_FONT;
+    case WXD_SYS_DEVICE_DEFAULT_FONT:
+        return wxSYS_DEVICE_DEFAULT_FONT;
+    case WXD_SYS_SYSTEM_FIXED_FONT:
+        return wxSYS_SYSTEM_FIXED_FONT;
+    case WXD_SYS_DEFAULT_GUI_FONT:
+        return wxSYS_DEFAULT_GUI_FONT;
+    }
+    return wxSYS_DEFAULT_GUI_FONT;
+}
+
+wxSystemMetric
+map_system_metric(wxd_SystemMetric index)
+{
+    switch (index) {
+    case WXD_SYS_MOUSE_BUTTONS:
+        return wxSYS_MOUSE_BUTTONS;
+    case WXD_SYS_BORDER_X:
+        return wxSYS_BORDER_X;
+    case WXD_SYS_BORDER_Y:
+        return wxSYS_BORDER_Y;
+    case WXD_SYS_CURSOR_SIZE:
+        return wxSYS_CURSOR_SIZE;
+    case WXD_SYS_DCLICK_X:
+        return wxSYS_DCLICK_X;
+    case WXD_SYS_DCLICK_Y:
+        return wxSYS_DCLICK_Y;
+    case WXD_SYS_DRAG_X:
+        return wxSYS_DRAG_X;
+    case WXD_SYS_DRAG_Y:
+        return wxSYS_DRAG_Y;
+    case WXD_SYS_EDGE_X:
+        return wxSYS_EDGE_X;
+    case WXD_SYS_EDGE_Y:
+        return wxSYS_EDGE_Y;
+    case WXD_SYS_HSCROLL_ARROW_X:
+        return wxSYS_HSCROLL_ARROW_X;
+    case WXD_SYS_HSCROLL_ARROW_Y:
+        return wxSYS_HSCROLL_ARROW_Y;
+    case WXD_SYS_HTHUMB_X:
+        return wxSYS_HTHUMB_X;
+    case WXD_SYS_ICON_X:
+        return wxSYS_ICON_X;
+    case WXD_SYS_ICON_Y:
+        return wxSYS_ICON_Y;
+    case WXD_SYS_ICONSPACING_X:
+        return wxSYS_ICONSPACING_X;
+    case WXD_SYS_ICONSPACING_Y:
+        return wxSYS_ICONSPACING_Y;
+    case WXD_SYS_WINDOWMIN_X:
+        return wxSYS_WINDOWMIN_X;
+    case WXD_SYS_WINDOWMIN_Y:
+        return wxSYS_WINDOWMIN_Y;
+    case WXD_SYS_SCREEN_X:
+        return wxSYS_SCREEN_X;
+    case WXD_SYS_SCREEN_Y:
+        return wxSYS_SCREEN_Y;
+    case WXD_SYS_FRAMESIZE_X:
+        return wxSYS_FRAMESIZE_X;
+    case WXD_SYS_FRAMESIZE_Y:
+        return wxSYS_FRAMESIZE_Y;
+    case WXD_SYS_SMALLICON_X:
+        return wxSYS_SMALLICON_X;
+    case WXD_SYS_SMALLICON_Y:
+        return wxSYS_SMALLICON_Y;
+    case WXD_SYS_HSCROLL_Y:
+        return wxSYS_HSCROLL_Y;
+    case WXD_SYS_VSCROLL_X:
+        return wxSYS_VSCROLL_X;
+    case WXD_SYS_VSCROLL_ARROW_X:
+        return wxSYS_VSCROLL_ARROW_X;
+    case WXD_SYS_VSCROLL_ARROW_Y:
+        return wxSYS_VSCROLL_ARROW_Y;
+    case WXD_SYS_VTHUMB_Y:
+        return wxSYS_VTHUMB_Y;
+    case WXD_SYS_CAPTION_Y:
+        return wxSYS_CAPTION_Y;
+    case WXD_SYS_MENU_Y:
+        return wxSYS_MENU_Y;
+    case WXD_SYS_NETWORK_PRESENT:
+        return wxSYS_NETWORK_PRESENT;
+    case WXD_SYS_PENWINDOWS_PRESENT:
+        return wxSYS_PENWINDOWS_PRESENT;
+    case WXD_SYS_SHOW_SOUNDS:
+        return wxSYS_SHOW_SOUNDS;
+    case WXD_SYS_SWAP_BUTTONS:
+        return wxSYS_SWAP_BUTTONS;
+    case WXD_SYS_DCLICK_MSEC:
+        return wxSYS_DCLICK_MSEC;
+    case WXD_SYS_CARET_ON_MSEC:
+        return wxSYS_CARET_ON_MSEC;
+    case WXD_SYS_CARET_OFF_MSEC:
+        return wxSYS_CARET_OFF_MSEC;
+    case WXD_SYS_CARET_TIMEOUT_MSEC:
+        return wxSYS_CARET_TIMEOUT_MSEC;
+    }
+    return wxSYS_SCREEN_X;
+}
+
+} // namespace
+
+extern "C" {
+
+WXD_EXPORTED wxd_Colour_t
+wxd_SystemSettings_GetColour(wxd_SystemColour index)
+{
+    wxColour colour = wxSystemSettings::GetColour(map_system_colour(index));
+    return { colour.Red(), colour.Green(), colour.Blue(), colour.Alpha() };
+}
+
+WXD_EXPORTED wxd_Font_t*
+wxd_SystemSettings_GetFont(wxd_SystemFont index)
+{
+    wxFont font = wxSystemSettings::GetFont(map_system_font(index));
+    if (!font.IsOk())
+        return nullptr;
+    return reinterpret_cast<wxd_Font_t*>(new wxFont(font));
+}
+
+WXD_EXPORTED int
+wxd_SystemSettings_GetMetric(wxd_SystemMetric index, wxd_Window_t* win)
+{
+    const wxWindow* window = reinterpret_cast<const wxWindow*>(win);
+    return wxSystemSettings::GetMetric(map_system_metric(index), window);
+}
+
+} // extern "C"

--- a/rust/wxdragon/src/lib.rs
+++ b/rust/wxdragon/src/lib.rs
@@ -35,6 +35,7 @@ pub mod single_instance_checker;
 pub mod sizers;
 pub mod sound;
 pub mod sysopt;
+pub mod syssettings;
 pub mod timer;
 pub mod translations;
 pub mod types;

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -23,6 +23,7 @@ pub use crate::language::Language;
 pub use crate::sizers::WxSizer;
 pub use crate::sound::{Sound, SoundFlags};
 pub use crate::sysopt::SystemOptions;
+pub use crate::syssettings::{SystemColour, SystemFont, SystemMetric, SystemSettings};
 pub use crate::types::Style;
 pub use crate::utils::{ArrayString, BrowserLaunchFlags, bell, launch_default_browser};
 pub use crate::window::{BackgroundStyle, ExtraWindowStyle, Window, WindowStyle, WxWidget, WxWidgetDowncast};

--- a/rust/wxdragon/src/syssettings.rs
+++ b/rust/wxdragon/src/syssettings.rs
@@ -1,0 +1,261 @@
+//! Access to native, platform-appropriate UI colours, fonts, and metrics.
+//!
+//! This wraps `wxSystemSettings`, which is the supported way to match the host
+//! platform's look and feel when drawing custom controls, instead of hard-coding
+//! colours or sizes that would look wrong (or break entirely) under a different
+//! theme, DPI setting, or OS.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use wxdragon::prelude::*;
+//! use wxdragon::syssettings::{SystemColour, SystemMetric, SystemSettings};
+//!
+//! let window_bg = SystemSettings::get_colour(SystemColour::Window);
+//! let highlight = SystemSettings::get_colour(SystemColour::Highlight);
+//! let border_width = SystemSettings::get_metric(SystemMetric::BorderX, None);
+//! ```
+
+use crate::color::Colour;
+use crate::font::Font;
+use crate::window::WxWidget;
+use wxdragon_sys as ffi;
+
+/// Identifies a standard system colour, as used by [`SystemSettings::get_colour`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum SystemColour {
+    Scrollbar,
+    Desktop,
+    ActiveCaption,
+    InactiveCaption,
+    Menu,
+    Window,
+    WindowFrame,
+    MenuText,
+    WindowText,
+    CaptionText,
+    ActiveBorder,
+    InactiveBorder,
+    AppWorkspace,
+    Highlight,
+    HighlightText,
+    BtnFace,
+    BtnShadow,
+    GrayText,
+    BtnText,
+    InactiveCaptionText,
+    BtnHighlight,
+    ThreeDDkShadow,
+    ThreeDLight,
+    InfoText,
+    InfoBk,
+    ListBox,
+    HotLight,
+    GradientActiveCaption,
+    GradientInactiveCaption,
+    MenuHilight,
+    MenuBar,
+    ListBoxText,
+    ListBoxHighlightText,
+    GridLines,
+    ListBoxHighlight,
+}
+
+impl SystemColour {
+    fn to_raw(self) -> ffi::wxd_SystemColour {
+        match self {
+            SystemColour::Scrollbar => ffi::wxd_SystemColour_WXD_SYS_COLOUR_SCROLLBAR,
+            SystemColour::Desktop => ffi::wxd_SystemColour_WXD_SYS_COLOUR_DESKTOP,
+            SystemColour::ActiveCaption => ffi::wxd_SystemColour_WXD_SYS_COLOUR_ACTIVECAPTION,
+            SystemColour::InactiveCaption => ffi::wxd_SystemColour_WXD_SYS_COLOUR_INACTIVECAPTION,
+            SystemColour::Menu => ffi::wxd_SystemColour_WXD_SYS_COLOUR_MENU,
+            SystemColour::Window => ffi::wxd_SystemColour_WXD_SYS_COLOUR_WINDOW,
+            SystemColour::WindowFrame => ffi::wxd_SystemColour_WXD_SYS_COLOUR_WINDOWFRAME,
+            SystemColour::MenuText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_MENUTEXT,
+            SystemColour::WindowText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_WINDOWTEXT,
+            SystemColour::CaptionText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_CAPTIONTEXT,
+            SystemColour::ActiveBorder => ffi::wxd_SystemColour_WXD_SYS_COLOUR_ACTIVEBORDER,
+            SystemColour::InactiveBorder => ffi::wxd_SystemColour_WXD_SYS_COLOUR_INACTIVEBORDER,
+            SystemColour::AppWorkspace => ffi::wxd_SystemColour_WXD_SYS_COLOUR_APPWORKSPACE,
+            SystemColour::Highlight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_HIGHLIGHT,
+            SystemColour::HighlightText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_HIGHLIGHTTEXT,
+            SystemColour::BtnFace => ffi::wxd_SystemColour_WXD_SYS_COLOUR_BTNFACE,
+            SystemColour::BtnShadow => ffi::wxd_SystemColour_WXD_SYS_COLOUR_BTNSHADOW,
+            SystemColour::GrayText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_GRAYTEXT,
+            SystemColour::BtnText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_BTNTEXT,
+            SystemColour::InactiveCaptionText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_INACTIVECAPTIONTEXT,
+            SystemColour::BtnHighlight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_BTNHIGHLIGHT,
+            SystemColour::ThreeDDkShadow => ffi::wxd_SystemColour_WXD_SYS_COLOUR_3DDKSHADOW,
+            SystemColour::ThreeDLight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_3DLIGHT,
+            SystemColour::InfoText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_INFOTEXT,
+            SystemColour::InfoBk => ffi::wxd_SystemColour_WXD_SYS_COLOUR_INFOBK,
+            SystemColour::ListBox => ffi::wxd_SystemColour_WXD_SYS_COLOUR_LISTBOX,
+            SystemColour::HotLight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_HOTLIGHT,
+            SystemColour::GradientActiveCaption => ffi::wxd_SystemColour_WXD_SYS_COLOUR_GRADIENTACTIVECAPTION,
+            SystemColour::GradientInactiveCaption => ffi::wxd_SystemColour_WXD_SYS_COLOUR_GRADIENTINACTIVECAPTION,
+            SystemColour::MenuHilight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_MENUHILIGHT,
+            SystemColour::MenuBar => ffi::wxd_SystemColour_WXD_SYS_COLOUR_MENUBAR,
+            SystemColour::ListBoxText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_LISTBOXTEXT,
+            SystemColour::ListBoxHighlightText => ffi::wxd_SystemColour_WXD_SYS_COLOUR_LISTBOXHIGHLIGHTTEXT,
+            SystemColour::GridLines => ffi::wxd_SystemColour_WXD_SYS_COLOUR_GRIDLINES,
+            SystemColour::ListBoxHighlight => ffi::wxd_SystemColour_WXD_SYS_COLOUR_LISTBOXHIGHLIGHT,
+        }
+    }
+}
+
+/// Identifies a standard system font, as used by [`SystemSettings::get_font`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum SystemFont {
+    OemFixedFont,
+    AnsiFixedFont,
+    AnsiVarFont,
+    SystemFont,
+    DeviceDefaultFont,
+    SystemFixedFont,
+    /// The default font used for controls and dialogs; this is almost always the one you want.
+    DefaultGuiFont,
+}
+
+impl SystemFont {
+    fn to_raw(self) -> ffi::wxd_SystemFont {
+        match self {
+            SystemFont::OemFixedFont => ffi::wxd_SystemFont_WXD_SYS_OEM_FIXED_FONT,
+            SystemFont::AnsiFixedFont => ffi::wxd_SystemFont_WXD_SYS_ANSI_FIXED_FONT,
+            SystemFont::AnsiVarFont => ffi::wxd_SystemFont_WXD_SYS_ANSI_VAR_FONT,
+            SystemFont::SystemFont => ffi::wxd_SystemFont_WXD_SYS_SYSTEM_FONT,
+            SystemFont::DeviceDefaultFont => ffi::wxd_SystemFont_WXD_SYS_DEVICE_DEFAULT_FONT,
+            SystemFont::SystemFixedFont => ffi::wxd_SystemFont_WXD_SYS_SYSTEM_FIXED_FONT,
+            SystemFont::DefaultGuiFont => ffi::wxd_SystemFont_WXD_SYS_DEFAULT_GUI_FONT,
+        }
+    }
+}
+
+/// Identifies a system-dependent metric, as used by [`SystemSettings::get_metric`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum SystemMetric {
+    MouseButtons,
+    BorderX,
+    BorderY,
+    /// Width/height of a cursor; cursors are always square, so a single value covers both.
+    CursorSize,
+    DClickX,
+    DClickY,
+    DragX,
+    DragY,
+    EdgeX,
+    EdgeY,
+    HScrollArrowX,
+    HScrollArrowY,
+    HThumbX,
+    IconX,
+    IconY,
+    IconSpacingX,
+    IconSpacingY,
+    WindowMinX,
+    WindowMinY,
+    ScreenX,
+    ScreenY,
+    FrameSizeX,
+    FrameSizeY,
+    SmallIconX,
+    SmallIconY,
+    HScrollY,
+    VScrollX,
+    VScrollArrowX,
+    VScrollArrowY,
+    VThumbY,
+    CaptionY,
+    MenuY,
+    /// Non-zero if a network is present.
+    NetworkPresent,
+    PenWindowsPresent,
+    /// Non-zero if the user prefers visual accompaniments for sounds.
+    ShowSounds,
+    /// Non-zero if the primary/secondary mouse buttons are swapped.
+    SwapButtons,
+    DClickMsec,
+    CaretOnMsec,
+    CaretOffMsec,
+    CaretTimeoutMsec,
+}
+
+impl SystemMetric {
+    fn to_raw(self) -> ffi::wxd_SystemMetric {
+        match self {
+            SystemMetric::MouseButtons => ffi::wxd_SystemMetric_WXD_SYS_MOUSE_BUTTONS,
+            SystemMetric::BorderX => ffi::wxd_SystemMetric_WXD_SYS_BORDER_X,
+            SystemMetric::BorderY => ffi::wxd_SystemMetric_WXD_SYS_BORDER_Y,
+            SystemMetric::CursorSize => ffi::wxd_SystemMetric_WXD_SYS_CURSOR_SIZE,
+            SystemMetric::DClickX => ffi::wxd_SystemMetric_WXD_SYS_DCLICK_X,
+            SystemMetric::DClickY => ffi::wxd_SystemMetric_WXD_SYS_DCLICK_Y,
+            SystemMetric::DragX => ffi::wxd_SystemMetric_WXD_SYS_DRAG_X,
+            SystemMetric::DragY => ffi::wxd_SystemMetric_WXD_SYS_DRAG_Y,
+            SystemMetric::EdgeX => ffi::wxd_SystemMetric_WXD_SYS_EDGE_X,
+            SystemMetric::EdgeY => ffi::wxd_SystemMetric_WXD_SYS_EDGE_Y,
+            SystemMetric::HScrollArrowX => ffi::wxd_SystemMetric_WXD_SYS_HSCROLL_ARROW_X,
+            SystemMetric::HScrollArrowY => ffi::wxd_SystemMetric_WXD_SYS_HSCROLL_ARROW_Y,
+            SystemMetric::HThumbX => ffi::wxd_SystemMetric_WXD_SYS_HTHUMB_X,
+            SystemMetric::IconX => ffi::wxd_SystemMetric_WXD_SYS_ICON_X,
+            SystemMetric::IconY => ffi::wxd_SystemMetric_WXD_SYS_ICON_Y,
+            SystemMetric::IconSpacingX => ffi::wxd_SystemMetric_WXD_SYS_ICONSPACING_X,
+            SystemMetric::IconSpacingY => ffi::wxd_SystemMetric_WXD_SYS_ICONSPACING_Y,
+            SystemMetric::WindowMinX => ffi::wxd_SystemMetric_WXD_SYS_WINDOWMIN_X,
+            SystemMetric::WindowMinY => ffi::wxd_SystemMetric_WXD_SYS_WINDOWMIN_Y,
+            SystemMetric::ScreenX => ffi::wxd_SystemMetric_WXD_SYS_SCREEN_X,
+            SystemMetric::ScreenY => ffi::wxd_SystemMetric_WXD_SYS_SCREEN_Y,
+            SystemMetric::FrameSizeX => ffi::wxd_SystemMetric_WXD_SYS_FRAMESIZE_X,
+            SystemMetric::FrameSizeY => ffi::wxd_SystemMetric_WXD_SYS_FRAMESIZE_Y,
+            SystemMetric::SmallIconX => ffi::wxd_SystemMetric_WXD_SYS_SMALLICON_X,
+            SystemMetric::SmallIconY => ffi::wxd_SystemMetric_WXD_SYS_SMALLICON_Y,
+            SystemMetric::HScrollY => ffi::wxd_SystemMetric_WXD_SYS_HSCROLL_Y,
+            SystemMetric::VScrollX => ffi::wxd_SystemMetric_WXD_SYS_VSCROLL_X,
+            SystemMetric::VScrollArrowX => ffi::wxd_SystemMetric_WXD_SYS_VSCROLL_ARROW_X,
+            SystemMetric::VScrollArrowY => ffi::wxd_SystemMetric_WXD_SYS_VSCROLL_ARROW_Y,
+            SystemMetric::VThumbY => ffi::wxd_SystemMetric_WXD_SYS_VTHUMB_Y,
+            SystemMetric::CaptionY => ffi::wxd_SystemMetric_WXD_SYS_CAPTION_Y,
+            SystemMetric::MenuY => ffi::wxd_SystemMetric_WXD_SYS_MENU_Y,
+            SystemMetric::NetworkPresent => ffi::wxd_SystemMetric_WXD_SYS_NETWORK_PRESENT,
+            SystemMetric::PenWindowsPresent => ffi::wxd_SystemMetric_WXD_SYS_PENWINDOWS_PRESENT,
+            SystemMetric::ShowSounds => ffi::wxd_SystemMetric_WXD_SYS_SHOW_SOUNDS,
+            SystemMetric::SwapButtons => ffi::wxd_SystemMetric_WXD_SYS_SWAP_BUTTONS,
+            SystemMetric::DClickMsec => ffi::wxd_SystemMetric_WXD_SYS_DCLICK_MSEC,
+            SystemMetric::CaretOnMsec => ffi::wxd_SystemMetric_WXD_SYS_CARET_ON_MSEC,
+            SystemMetric::CaretOffMsec => ffi::wxd_SystemMetric_WXD_SYS_CARET_OFF_MSEC,
+            SystemMetric::CaretTimeoutMsec => ffi::wxd_SystemMetric_WXD_SYS_CARET_TIMEOUT_MSEC,
+        }
+    }
+}
+
+/// Provides access to native, platform-appropriate UI colours, fonts, and metrics.
+pub struct SystemSettings;
+
+impl SystemSettings {
+    /// Returns a standard system colour, such as the native window background or highlight colour.
+    pub fn get_colour(index: SystemColour) -> Colour {
+        let raw = unsafe { ffi::wxd_SystemSettings_GetColour(index.to_raw()) };
+        Colour::from(raw)
+    }
+
+    /// Returns a standard system font, such as the default GUI font used by controls and dialogs.
+    ///
+    /// Returns `None` if the requested font is not available on this platform.
+    pub fn get_font(index: SystemFont) -> Option<Font> {
+        let ptr = unsafe { ffi::wxd_SystemSettings_GetFont(index.to_raw()) };
+        if ptr.is_null() {
+            return None;
+        }
+        Some(unsafe { Font::from_ptr(ptr, true) })
+    }
+
+    /// Returns a system-dependent metric, such as a scrollbar's width or the double-click distance.
+    ///
+    /// If `window` is given, the metric is scaled for the display that window is on, which
+    /// matters on multi-monitor setups where displays can have different DPI settings.
+    pub fn get_metric(index: SystemMetric, window: Option<&dyn WxWidget>) -> i32 {
+        let window_ptr = window.map_or(std::ptr::null_mut(), |w| w.handle_ptr());
+        unsafe { ffi::wxd_SystemSettings_GetMetric(index.to_raw(), window_ptr) }
+    }
+}


### PR DESCRIPTION
## Summary
- Wraps `wxSystemSettings::GetColour`/`GetFont`/`GetMetric`, which were only used internally (in `app.cpp`/`window.cpp`) and never exposed to Rust callers
- Adds `SystemColour`, `SystemFont`, and `SystemMetric` enums plus a `SystemSettings` struct with `get_colour`, `get_font`, and `get_metric` (the latter optionally scaled for a given window's display, useful on multi-monitor/mixed-DPI setups)
- Lets custom-drawn or dark-mode-aware widgets match the native theme (window/highlight/text colours, the default GUI font, scrollbar width, double-click distance, etc.) instead of hard-coding values that break under a different theme or platform
- FFI enums (`wxd_SystemColour`/`wxd_SystemFont`/`wxd_SystemMetric`) are wxd-internal and mapped explicitly to the real `wxSystemColour`/`wxSystemFont`/`wxSystemMetric` values in `syssettings.cpp`, so they don't depend on wxWidgets' own platform-sensitive numbering — following the same pattern already used for `StockCursor`

## Test plan
- [x] `cargo build -p wxdragon` (full CMake + bindgen rebuild)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p wxdragon` (no warnings)
- [x] `cargo test --doc -p wxdragon syssettings` (module doc example compiles)