### PR TITLE
Add ColourDatabase wrapper for wxTheColourDatabase

### DIFF
--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -144,6 +144,7 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/collapsiblepane.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cursor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/colourdatabase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/colourdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/colourpickerctrl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/combobox.cpp

--- a/rust/wxdragon-sys/cpp/include/core/wxd_colourdatabase.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_colourdatabase.h
@@ -1,0 +1,45 @@
+#ifndef WXD_COLOURDATABASE_H
+#define WXD_COLOURDATABASE_H
+
+#include "../wxd_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Colour scheme used by the global colour database. CSS is the wxWidgets 3.3.0+ default
+// (matching CSS/web colour names); Traditional is the legacy scheme used before that.
+typedef enum {
+    WXD_COLOUR_DATABASE_SCHEME_CSS = 0,
+    WXD_COLOUR_DATABASE_SCHEME_TRADITIONAL = 1
+} wxd_ColourDatabaseScheme;
+
+// Selects which colour scheme the database's built-in names use.
+WXD_EXPORTED void
+wxd_ColourDatabase_UseScheme(wxd_ColourDatabaseScheme scheme);
+
+// Looks up a colour by name (e.g. "MEDIUM FOREST GREEN"), case-insensitive.
+// Returns true and fills `out_colour` if found, false (leaving `out_colour` untouched) otherwise.
+WXD_EXPORTED bool
+wxd_ColourDatabase_Find(const char* name, wxd_Colour_t* out_colour);
+
+// Looks up the name for a colour. Returns the required buffer length in bytes (excluding
+// the null terminator), or 0 if the colour has no name in the database. Follows the same
+// call-twice pattern as the other wxd string getters.
+WXD_EXPORTED int
+wxd_ColourDatabase_FindName(wxd_Colour_t colour, char* buffer, size_t buffer_len);
+
+// Adds (or overwrites) a named colour in the database.
+WXD_EXPORTED void
+wxd_ColourDatabase_AddColour(const char* name, wxd_Colour_t colour);
+
+// Returns all colour names currently known to the database, as a newly allocated
+// wxd_ArrayString_t* owned by the caller (free with wxd_ArrayString_Free).
+WXD_EXPORTED wxd_ArrayString_t*
+wxd_ColourDatabase_GetAllNames(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_COLOURDATABASE_H

--- a/rust/wxdragon-sys/cpp/include/wxdragon.h
+++ b/rust/wxdragon-sys/cpp/include/wxdragon.h
@@ -158,6 +158,7 @@ extern "C" {
 #include "core/wxd_singleinstancechecker.h"
 #include "core/wxd_uiactionsimulator.h"
 #include "core/wxd_config.h"
+#include "core/wxd_colourdatabase.h"
 #include "core/wxd_misc.h"
 
 #ifdef __cplusplus

--- a/rust/wxdragon-sys/cpp/src/colourdatabase.cpp
+++ b/rust/wxdragon-sys/cpp/src/colourdatabase.cpp
@@ -1,0 +1,63 @@
+#include <wx/wxprec.h>
+#include <wx/wx.h>
+#include "../include/wxdragon.h"
+#include "wxd_utils.h"
+
+extern "C" {
+
+WXD_EXPORTED void
+wxd_ColourDatabase_UseScheme(wxd_ColourDatabaseScheme scheme)
+{
+    if (!wxTheColourDatabase)
+        return;
+    wxTheColourDatabase->UseScheme(scheme == WXD_COLOUR_DATABASE_SCHEME_TRADITIONAL ? wxColourDatabase::Traditional
+                                                                                     : wxColourDatabase::CSS);
+}
+
+WXD_EXPORTED bool
+wxd_ColourDatabase_Find(const char* name, wxd_Colour_t* out_colour)
+{
+    if (!wxTheColourDatabase || !name || !out_colour)
+        return false;
+
+    wxColour colour = wxTheColourDatabase->Find(wxString::FromUTF8(name));
+    if (!colour.IsOk())
+        return false;
+
+    *out_colour = { colour.Red(), colour.Green(), colour.Blue(), colour.Alpha() };
+    return true;
+}
+
+WXD_EXPORTED int
+wxd_ColourDatabase_FindName(wxd_Colour_t colour, char* buffer, size_t buffer_len)
+{
+    if (!wxTheColourDatabase)
+        return (int)wxd_cpp_utils::copy_wxstring_to_buffer(wxString(), buffer, buffer_len);
+
+    wxColour wx_colour(colour.r, colour.g, colour.b, colour.a);
+    wxString name = wxTheColourDatabase->FindName(wx_colour);
+    return (int)wxd_cpp_utils::copy_wxstring_to_buffer(name, buffer, buffer_len);
+}
+
+WXD_EXPORTED void
+wxd_ColourDatabase_AddColour(const char* name, wxd_Colour_t colour)
+{
+    if (!wxTheColourDatabase || !name)
+        return;
+    wxTheColourDatabase->AddColour(wxString::FromUTF8(name), wxColour(colour.r, colour.g, colour.b, colour.a));
+}
+
+WXD_EXPORTED wxd_ArrayString_t*
+wxd_ColourDatabase_GetAllNames(void)
+{
+    wxArrayString* names = new (std::nothrow) wxArrayString();
+    if (!names)
+        return nullptr;
+    if (wxTheColourDatabase) {
+        for (const wxString& name : wxTheColourDatabase->GetAllNames())
+            names->Add(name);
+    }
+    return reinterpret_cast<wxd_ArrayString_t*>(names);
+}
+
+} // extern "C"

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::sizers::WxSizer;
 pub use crate::sound::{Sound, SoundFlags};
 pub use crate::sysopt::SystemOptions;
 pub use crate::types::Style;
-pub use crate::utils::{ArrayString, BrowserLaunchFlags, bell, launch_default_browser};
+pub use crate::utils::{ArrayString, BrowserLaunchFlags, ColourDatabase, ColourDatabaseScheme, bell, launch_default_browser};
 pub use crate::window::{BackgroundStyle, ExtraWindowStyle, Window, WindowStyle, WxWidget, WxWidgetDowncast};
 
 // --- Sizers ---

--- a/rust/wxdragon/src/utils/colour_database.rs
+++ b/rust/wxdragon/src/utils/colour_database.rs
@@ -1,0 +1,110 @@
+//! Access to wxWidgets' global database of named stock colours.
+
+use crate::color::Colour;
+use crate::utils::ArrayString;
+use std::ffi::CString;
+use wxdragon_sys as ffi;
+
+/// Selects which built-in colour scheme [`ColourDatabase`] uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColourDatabaseScheme {
+    /// CSS/web colour names (e.g. `"MEDIUMSEAGREEN"`). The default since wxWidgets 3.3.0.
+    #[default]
+    Css,
+    /// The legacy colour names used by wxWidgets before 3.3.0 (e.g. `"MEDIUM SEA GREEN"`).
+    Traditional,
+}
+
+impl ColourDatabaseScheme {
+    fn to_raw(self) -> ffi::wxd_ColourDatabaseScheme {
+        match self {
+            ColourDatabaseScheme::Css => ffi::wxd_ColourDatabaseScheme_WXD_COLOUR_DATABASE_SCHEME_CSS,
+            ColourDatabaseScheme::Traditional => ffi::wxd_ColourDatabaseScheme_WXD_COLOUR_DATABASE_SCHEME_TRADITIONAL,
+        }
+    }
+}
+
+/// Provides access to wxWidgets' global database of named stock colours (e.g. looking up
+/// `"MEDIUM FOREST GREEN"` or finding the name for an RGB value), backed by `wxTheColourDatabase`.
+pub struct ColourDatabase;
+
+impl ColourDatabase {
+    /// Selects which built-in colour scheme the database's names use.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use wxdragon::utils::{ColourDatabase, ColourDatabaseScheme};
+    ///
+    /// ColourDatabase::use_scheme(ColourDatabaseScheme::Traditional);
+    /// ```
+    pub fn use_scheme(scheme: ColourDatabaseScheme) {
+        unsafe { ffi::wxd_ColourDatabase_UseScheme(scheme.to_raw()) };
+    }
+
+    /// Looks up a colour by name (case-insensitive), returning `None` if the name isn't known.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use wxdragon::utils::ColourDatabase;
+    ///
+    /// if let Some(colour) = ColourDatabase::find("MEDIUM FOREST GREEN") {
+    ///     println!("r={} g={} b={}", colour.r, colour.g, colour.b);
+    /// }
+    /// ```
+    pub fn find(name: &str) -> Option<Colour> {
+        let c_name = CString::new(name).ok()?;
+        let mut raw = ffi::wxd_Colour_t { r: 0, g: 0, b: 0, a: 0 };
+        let found = unsafe { ffi::wxd_ColourDatabase_Find(c_name.as_ptr(), &mut raw) };
+        if found { Some(Colour::from(raw)) } else { None }
+    }
+
+    /// Looks up the name for a colour, returning `None` if it has no name in the database.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use wxdragon::prelude::*;
+    /// use wxdragon::utils::ColourDatabase;
+    ///
+    /// let name = ColourDatabase::find_name(Colour::new(255, 0, 0, 255));
+    /// ```
+    pub fn find_name(colour: Colour) -> Option<String> {
+        let raw = colour.to_raw();
+        let len = unsafe { ffi::wxd_ColourDatabase_FindName(raw, std::ptr::null_mut(), 0) };
+        if len <= 0 {
+            return None;
+        }
+        let mut buffer = vec![0u8; len as usize + 1];
+        unsafe { ffi::wxd_ColourDatabase_FindName(raw, buffer.as_mut_ptr() as *mut std::os::raw::c_char, buffer.len()) };
+        Some(unsafe {
+            std::ffi::CStr::from_ptr(buffer.as_ptr() as *const std::os::raw::c_char)
+                .to_string_lossy()
+                .to_string()
+        })
+    }
+
+    /// Adds a named colour to the database, or overwrites the colour for an existing name.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use wxdragon::prelude::*;
+    /// use wxdragon::utils::ColourDatabase;
+    ///
+    /// ColourDatabase::add_colour("BRAND PURPLE", Colour::new(128, 0, 200, 255));
+    /// ```
+    pub fn add_colour(name: &str, colour: Colour) {
+        let Ok(c_name) = CString::new(name) else {
+            return;
+        };
+        unsafe { ffi::wxd_ColourDatabase_AddColour(c_name.as_ptr(), colour.to_raw()) };
+    }
+
+    /// Returns the names of all colours currently known to the database.
+    pub fn all_names() -> Vec<String> {
+        let ptr = unsafe { ffi::wxd_ColourDatabase_GetAllNames() };
+        if ptr.is_null() {
+            return Vec::new();
+        }
+        let names: ArrayString = ptr.into();
+        names.get_strings()
+    }
+}

--- a/rust/wxdragon/src/utils/mod.rs
+++ b/rust/wxdragon/src/utils/mod.rs
@@ -1,5 +1,7 @@
 mod array_string;
+mod colour_database;
 mod misc;
 
 pub use array_string::ArrayString;
+pub use colour_database::{ColourDatabase, ColourDatabaseScheme};
 pub use misc::{BrowserLaunchFlags, bell, launch_default_browser};


### PR DESCRIPTION
## Summary
- Wraps `wxTheColourDatabase` (the global `wxColourDatabase` instance), which had no bindings at all
- Adds `ColourDatabase::find(name)` / `find_name(colour)` for looking up a stock colour by name and vice versa, `add_colour(name, colour)` to register a custom name, and `all_names()` to enumerate every known name (~193 built-in colours)
- Adds `ColourDatabase::use_scheme(ColourDatabaseScheme)` to switch between the CSS naming scheme (the wxWidgets 3.3.0+ default) and the legacy `Traditional` names
- `all_names()` reuses the existing `ArrayString` FFI plumbing rather than introducing a new string-array transport
- Pairs naturally with the `SystemSettings` work from #175

## Test plan
- [x] `cargo build -p wxdragon`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p wxdragon` (no warnings)
- [x] `cargo test --doc -p wxdragon colour_database` (all 4 doc examples compile)
- [x] Ran a throwaway example at runtime: enumerated the built-in names (193), round-tripped `"MEDIUM FOREST GREEN"` through `find()`/`find_name()`, confirmed a bogus name and an arbitrary RGB triple both correctly report as not found, confirmed `add_colour()`'s new entry is immediately findable, and confirmed `use_scheme(Traditional)` doesn't crash and lookups still resolve correctly afterward