### PR TITLE
fix: isolate destroy events to their owning windows

### DIFF
--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -440,9 +440,11 @@ WxdEventHandler::DispatchEvent(wxEvent& event)
         }
     }
 
-    // If this is the destroy event, perform a final cleanup of all bound closures.
-    // This runs after all user destroy handlers have been invoked above.
-    if (eventType == wxEVT_DESTROY) {
+    // Release closures only when this handler's owning window is being destroyed.
+    // wxAUI destroys temporary floating windows while re-docking panes; their
+    // DESTROY events can reach the managed frame's handler, but must not release
+    // the frame's callbacks.
+    if (eventType == wxEVT_DESTROY && event.GetEventObject() == ownerHandler) {
         // Intentionally ignore the return value of UnbindAll() as we do not need to know
         // how many handlers were unbound; this is a final cleanup step.
         (void)this->UnbindAll();

--- a/rust/wxdragon/src/event/macros.rs
+++ b/rust/wxdragon/src/event/macros.rs
@@ -98,6 +98,50 @@ macro_rules! implement_category_event_handlers {
     }
 }
 
+/// Generates window event handlers that ignore destroy events from child windows.
+#[macro_export]
+macro_rules! implement_window_category_event_handlers {
+    ($trait_name:ident, $event_enum:ident, $event_data:ident,
+     $($variant:ident => $method_name:ident, $event_type:expr),+) => {
+        pub trait $trait_name: $crate::event::WxEvtHandler {
+            #[doc(hidden)]
+            fn bind_window_category_event<F>(&self, event_type: $crate::event::$event_enum, mut callback: F) -> $crate::event::EventToken
+            where
+                F: FnMut($crate::event::$event_data) + 'static
+            {
+                let event_type_ffi = match event_type {
+                    $($crate::event::$event_enum::$variant => $event_type,)*
+                };
+                let handler_ptr = unsafe { self.get_event_handler_ptr() } as *mut std::ffi::c_void;
+
+                let wrapper = move |event: $crate::event::Event| {
+                    if matches!(event_type, $crate::event::$event_enum::Destroy)
+                        && event
+                            .get_event_object()
+                            .is_none_or(|object| object.as_ptr().cast::<std::ffi::c_void>() != handler_ptr)
+                    {
+                        return;
+                    }
+                    callback($crate::event::$event_data::new(event));
+                };
+
+                $crate::event::WxEvtHandler::bind_internal(self, event_type_ffi, wrapper)
+            }
+
+            $(
+                paste::paste! {
+                    fn [<on_ $method_name>]<F>(&self, callback: F) -> $crate::event::EventToken
+                    where
+                        F: FnMut($crate::event::$event_data) + 'static
+                    {
+                        self.bind_window_category_event($crate::event::$event_enum::$variant, callback)
+                    }
+                }
+            )*
+        }
+    }
+}
+
 /// Generates internal binding method and public on_* methods for widget-specific events defined in the same module
 #[macro_export]
 macro_rules! implement_widget_local_event_handlers {

--- a/rust/wxdragon/src/event/window_events.rs
+++ b/rust/wxdragon/src/event/window_events.rs
@@ -332,7 +332,7 @@ impl ActivateEventData {
 }
 
 // Use the macro to implement the trait
-crate::implement_category_event_handlers!(
+crate::implement_window_category_event_handlers!(
     WindowEvents, WindowEvent, WindowEventData,
     LeftDown => mouse_left_down, EventType::LEFT_DOWN,
     LeftUp => mouse_left_up, EventType::LEFT_UP,

--- a/rust/wxdragon/src/widgets/aui_manager.rs
+++ b/rust/wxdragon/src/widgets/aui_manager.rs
@@ -396,9 +396,14 @@ impl<'a> AuiManagerBuilder<'a> {
 
         // Set up a destroy handler on the managed window to invalidate this manager
         let handle_copy = handle;
+        let managed_window_ptr = self.parent_ptr;
         let parent = unsafe { Window::from_ptr(self.parent_ptr) };
-        parent.bind_internal(EventType::DESTROY, move |_event| {
-            handle_copy.invalidate();
+        parent.bind_internal(EventType::DESTROY, move |event| {
+            if let Some(event_object) = event.get_event_object()
+                && event_object.as_ptr() == managed_window_ptr
+            {
+                handle_copy.invalidate();
+            }
         });
 
         mgr


### PR DESCRIPTION
Filter bubbled wxEVT_DESTROY events by their source window before invalidating AUI managers, dispatching WindowEvents::on_destroy callbacks, or releasing Rust event closures. This prevents AUI floating-pane re-docking from invalidating the managed frame and dropping its callbacks.