### PR TITLE
Add Frame full screen support

### DIFF
--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_frame.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_frame.h
@@ -63,6 +63,12 @@ WXD_EXPORTED bool
 wxd_Frame_IsMaximized(wxd_Frame_t* frame);
 
 WXD_EXPORTED void
+wxd_Frame_ShowFullScreen(wxd_Frame_t* frame, bool show);
+
+WXD_EXPORTED bool
+wxd_Frame_IsFullScreen(wxd_Frame_t* frame);
+
+WXD_EXPORTED void
 wxd_Frame_SetIconFromBitmap(wxd_Frame_t* frame, const wxd_Bitmap_t* bitmap);
 
 WXD_EXPORTED void

--- a/rust/wxdragon-sys/cpp/src/frame.cpp
+++ b/rust/wxdragon-sys/cpp/src/frame.cpp
@@ -201,6 +201,23 @@ wxd_Frame_IsMaximized(wxd_Frame_t* frame)
 }
 
 void
+wxd_Frame_ShowFullScreen(wxd_Frame_t* frame, bool show)
+{
+    if (frame) {
+        ((wxFrame*)frame)->ShowFullScreen(show);
+    }
+}
+
+bool
+wxd_Frame_IsFullScreen(wxd_Frame_t* frame)
+{
+    if (frame) {
+        return ((wxFrame*)frame)->IsFullScreen();
+    }
+    return false;
+}
+
+void
 wxd_Frame_SetIconFromBitmap(wxd_Frame_t* frame, const wxd_Bitmap_t* bitmap)
 {
     if (!frame || !bitmap)

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -435,6 +435,26 @@ impl Frame {
         unsafe { ffi::wxd_Frame_IsMaximized(ptr) }
     }
 
+    /// Shows or hides the frame in full screen mode.
+    /// No-op if the frame has been destroyed.
+    pub fn show_full_screen(&self, show: bool) {
+        let ptr = self.frame_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_Frame_ShowFullScreen(ptr, show) }
+    }
+
+    /// Returns true if the frame is currently in full screen mode.
+    /// Returns false if the frame has been destroyed.
+    pub fn is_full_screen(&self) -> bool {
+        let ptr = self.frame_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_Frame_IsFullScreen(ptr) }
+    }
+
     /// Sets the frame's icon from a bitmap.
     /// The bitmap will be converted to an icon internally.
     /// No-op if the frame has been destroyed.


### PR DESCRIPTION
## Summary
- Adds wxd_Frame_ShowFullScreen and wxd_Frame_IsFullScreen, wrapping wxFrame's existing ShowFullScreen/IsFullScreen methods, the same pattern already used for Maximize/IsMaximized.
- Adds show_full_screen and is_full_screen methods to the Rust Frame wrapper.

## Motivation
A downstream app needs full screen support for a document reading window, and this was missing from the Frame API.

## Test plan
- cargo build -p wxdragon succeeds locally.