### PR TITLE
feat(sys): allow relocating the CMake build dirs via environment variables

### DIFF
--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -8,6 +8,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     println!("cargo::rerun-if-changed=cpp");
     println!("cargo::rerun-if-changed=src");
     println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-env-changed=WXWIDGETS_DIR");
+    println!("cargo::rerun-if-env-changed=WXWIDGETS_BUILD_DIR");
+    println!("cargo::rerun-if-env-changed=WXDRAGON_SYS_BUILD_DIR");
 
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
@@ -202,8 +205,14 @@ fn build_wxdragon_wrapper(
     // so different feature combinations get separate builds without conflicts.
     // Additionally append the target triple so that native vs cross builds do not
     // stomp on each other when the same profile is reused (e.g. `debug`).
-    let wxdragon_sys_build_dir = dest_bin_dir.join("wxdragon_sys_cmake_build");
-    let wxwidgets_build_dir = dest_bin_dir.join("wxwidgets_cmake_build");
+    // Both directories can be relocated through environment variables (mirroring
+    // WXWIDGETS_DIR for the source), e.g. to a location a CI cache preserves.
+    let wxdragon_sys_build_dir = std::env::var("WXDRAGON_SYS_BUILD_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| dest_bin_dir.join("wxdragon_sys_cmake_build"));
+    let wxwidgets_build_dir = std::env::var("WXWIDGETS_BUILD_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| dest_bin_dir.join("wxwidgets_cmake_build"));
 
     let mut cmake_config = cmake::Config::new(libwxdragon_cmake_source_dir);
     cmake_config.out_dir(&wxdragon_sys_build_dir);


### PR DESCRIPTION
Closes #182.

The build script compiles wxWidgets and the wrapper library through CMake. It writes both build trees to fixed directories at the profile level of cargo's target directory. The download location of the wxWidgets source is already configurable through the `WXWIDGETS_DIR` environment variable, but the two build directories are not configurable at all.

Continuous integration caches need these trees to be relocatable. The common Rust cache action cleans unrecognized directories out of the target directory before saving, so the fixed locations force a full wxWidgets rebuild on every CI run. Pointing the trees at a directory the cache preserves avoids that without consumers having to hard-code the crate's internal paths.

This change makes both directories configurable, following the pattern `WXWIDGETS_DIR` already established:

- `WXDRAGON_SYS_BUILD_DIR` overrides the wrapper's build directory (default: `wxdragon_sys_cmake_build`).
- `WXWIDGETS_BUILD_DIR` overrides the wxWidgets build directory (default: `wxwidgets_cmake_build`).

When a variable is unset, the previous location is used, so existing builds are unaffected.

The build script now also emits `rerun-if-env-changed` for all three variables, including the pre-existing `WXWIDGETS_DIR`, so changing one of them retriggers the build script instead of silently reusing the old location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZyiWydqoemtUSY5ZryoFB
