### PR TITLE
Add SetRepresentedFilename for macOS title bar proxy icons

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -259,6 +259,13 @@ wxd_Window_SetAccessibilityValue(wxd_Window_t* window, const char* value);
 /// Equivalent to [NSRunningApplication activateWithOptions:NSApplicationActivateIgnoringOtherApps].
 WXD_EXPORTED void
 wxd_App_ActivateMac(void);
+
+/// Sets the top level window's title bar proxy icon to represent the given file
+/// path (macOS only). Lets the user Cmd-click the title to reveal the file's
+/// path in Finder, or drag the proxy icon to move/copy the file. Pass an empty
+/// string to clear it. No-op if window is not a top level window.
+WXD_EXPORTED void
+wxd_Window_SetRepresentedFilename(wxd_Window_t* window, const char* path);
 #endif
 
 // --- Popup Menu Functions ---

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -1,6 +1,7 @@
 #import <AppKit/AppKit.h>
 #include "../include/wxdragon.h"
 #include <wx/textctrl.h>
+#include <wx/toplevel.h>
 
 void
 wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label)
@@ -48,4 +49,15 @@ wxd_TextCtrl_DisableAllSmartSubstitutions(wxd_TextCtrl_t* textCtrl)
     if (!textCtrl) return;
     wxTextCtrl* wx_ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
     wx_ctrl->OSXDisableAllSmartSubstitutions();
+}
+
+void
+wxd_Window_SetRepresentedFilename(wxd_Window_t* window, const char* path)
+{
+    if (!window || !path) return;
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    wxTopLevelWindow* tlw = wxDynamicCast(wx_window, wxTopLevelWindow);
+    if (tlw) {
+        tlw->SetRepresentedFilename(wxString::FromUTF8(path));
+    }
 }

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -141,6 +141,8 @@ unsafe extern "C" {
     unsafe fn wxd_Window_SetAccessibilityValue(window: *mut ffi::wxd_Window_t, value: *const std::os::raw::c_char);
     #[cfg(target_os = "macos")]
     pub(crate) unsafe fn wxd_App_ActivateMac();
+    #[cfg(target_os = "macos")]
+    unsafe fn wxd_Window_SetRepresentedFilename(window: *mut ffi::wxd_Window_t, path: *const std::os::raw::c_char);
 }
 
 /// Marshals `s` to a C string and passes it to a `(window, *const c_char)` FFI setter.
@@ -1663,6 +1665,24 @@ pub trait WxWidget: std::any::Any {
         set_accessibility_string(handle, description, ffi::wxd_Window_SetAccessibleDescription);
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         let _ = description;
+    }
+
+    /// Sets a top level window's title bar proxy icon to represent the given file
+    /// path (macOS only). Lets the user Cmd-click the title bar to reveal the
+    /// file's location in Finder, or drag the proxy icon to move/copy the file.
+    /// Pass an empty string to clear it.
+    ///
+    /// No-op if this window is not a top level window (a `Frame` or `Dialog`), and
+    /// a no-op on other platforms.
+    fn set_represented_filename(&self, path: &str) {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return;
+        }
+        #[cfg(target_os = "macos")]
+        set_accessibility_string(handle, path, wxd_Window_SetRepresentedFilename);
+        #[cfg(not(target_os = "macos"))]
+        let _ = path;
     }
 
     /// Sets the accessible value for the window.


### PR DESCRIPTION
## Summary
- Adds wxd_Window_SetRepresentedFilename (macOS only), wrapping wxTopLevelWindow::SetRepresentedFilename.
- Adds a set_represented_filename method on the WxWidget trait, following the same pattern as the existing set_accessibility_label/set_accessibility_description methods (macOS only, no-op elsewhere).

## Motivation
This is the standard mechanism native macOS document windows use for the title bar proxy icon: Cmd-clicking the window title shows the file's path in a Finder-style breadcrumb, and the icon itself can be dragged to move or copy the file. Apps that open documents from disk (editors, viewers, readers) generally want this, and wxWidgets already exposes it on the Cocoa port, it just was not wrapped yet.

## Test plan
- cargo build -p wxdragon succeeds locally.