### PR TITLE
Add SYS_COLOUR_CHANGED event type

### DIFF
--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -363,6 +363,7 @@ typedef enum {
     WXD_EVENT_TYPE_PG_COL_DRAGGING = 402,      // wxEVT_PG_COL_DRAGGING
     WXD_EVENT_TYPE_PG_COL_END_DRAG = 403,      // wxEVT_PG_COL_END_DRAG
     WXD_EVENT_TYPE_MAGNIFY = 404,              // wxEVT_MAGNIFY
+    WXD_EVENT_TYPE_SYS_COLOUR_CHANGED = 406,   // wxEVT_SYS_COLOUR_CHANGED
     WXD_EVENT_TYPE_FSWATCHER = 407,            // wxEVT_FSWATCHER
 
     WXD_EVENT_TYPE_MAX // Keep this last for count if needed, or remove if not used for iteration

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -1014,6 +1014,8 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_MOUSEWHEEL;
     case WXD_EVENT_TYPE_MAGNIFY:
         return wxEVT_MAGNIFY;
+    case WXD_EVENT_TYPE_SYS_COLOUR_CHANGED:
+        return wxEVT_SYS_COLOUR_CHANGED;
     case WXD_EVENT_TYPE_FSWATCHER:
         return wxEVT_FSWATCHER;
 

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -126,6 +126,9 @@ pub struct EventType: ffi::WXDEventTypeCEnum { // Use the generated C enum type
     const MOTION = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOTION;
     const MOUSEWHEEL = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOUSEWHEEL;
     const MAGNIFY = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MAGNIFY;
+    /// Fired when the OS-level system colours/appearance change, e.g. switching
+    /// between light and dark mode.
+    const SYS_COLOUR_CHANGED = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_SYS_COLOUR_CHANGED;
     /// Fired by a `FileSystemWatcher` for changes to a watched path.
     const FSWATCHER = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_FSWATCHER;
     const ENTER_WINDOW = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_ENTER_WINDOW;


### PR DESCRIPTION
## Summary
- Adds WXD_EVENT_TYPE_SYS_COLOUR_CHANGED, mapped to wxEVT_SYS_COLOUR_CHANGED, following the same pattern as the other window-level event types (KEY_DOWN, MAGNIFY, and so on).
- Adds the corresponding EventType::SYS_COLOUR_CHANGED constant on the Rust side.

## Motivation
wxDragon already exposes a one shot query for the current system appearance (light or dark), but nothing fires when the OS-level appearance changes while the app is running, for example the user switching between light and dark mode in System Settings on macOS, or the equivalent on Windows. Any app doing custom painting based on the current appearance needs to react live to that change rather than only reading it once at startup. wxWidgets already emits wxEVT_SYS_COLOUR_CHANGED for this, it was just not wired up in the C or Rust binding layers yet. This is a small, generic addition, not platform gated, since the underlying wx event exists on all supported platforms.

## Test plan
- cargo build -p wxdragon succeeds locally.