### PR TITLE
Add TextCtrl::DisableAllSmartSubstitutions for macOS

### DIFF
--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_textctrl.h
@@ -161,4 +161,12 @@ wxd_TextCtrl_XYToPosition(wxd_TextCtrl_t* textCtrl, wxd_Long_t x, wxd_Long_t y);
 WXD_EXPORTED int
 wxd_TextCtrl_GetLineLength(wxd_TextCtrl_t* textCtrl, wxd_Long_t lineNo);
 
+#ifdef __WXOSX__
+/// Disables Cocoa's automatic smart quote/dash/substitution features for this
+/// text control (macOS only). Useful for fields where a user's literal input
+/// (a straight quote, a plain hyphen) should not be silently "corrected".
+WXD_EXPORTED void
+wxd_TextCtrl_DisableAllSmartSubstitutions(wxd_TextCtrl_t* textCtrl);
+#endif
+
 #endif // WXD_TEXTCTRL_H

--- a/rust/wxdragon-sys/cpp/src/window_osx.mm
+++ b/rust/wxdragon-sys/cpp/src/window_osx.mm
@@ -1,5 +1,6 @@
 #import <AppKit/AppKit.h>
 #include "../include/wxdragon.h"
+#include <wx/textctrl.h>
 
 void
 wxd_Window_SetAccessibilityLabel(wxd_Window_t* window, const char* label)
@@ -39,4 +40,12 @@ wxd_App_ActivateMac(void)
 {
     [[NSRunningApplication currentApplication]
         activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+}
+
+void
+wxd_TextCtrl_DisableAllSmartSubstitutions(wxd_TextCtrl_t* textCtrl)
+{
+    if (!textCtrl) return;
+    wxTextCtrl* wx_ctrl = reinterpret_cast<wxTextCtrl*>(textCtrl);
+    wx_ctrl->OSXDisableAllSmartSubstitutions();
 }

--- a/rust/wxdragon/src/widgets/textctrl.rs
+++ b/rust/wxdragon/src/widgets/textctrl.rs
@@ -14,6 +14,14 @@ use std::os::raw::c_char;
 use std::ptr::null_mut;
 use wxdragon_sys as ffi;
 
+// bindgen never defines __WXOSX__, so this mac-only declaration (guarded by
+// #ifdef __WXOSX__ in wxd_textctrl.h) is invisible to it; declare it locally and
+// call it directly instead of routing through the generated `ffi` module.
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    unsafe fn wxd_TextCtrl_DisableAllSmartSubstitutions(text_ctrl: *mut ffi::wxd_TextCtrl_t);
+}
+
 // --- Text Control Styles ---
 widget_style_enum!(
     name: TextCtrlStyle,
@@ -357,6 +365,21 @@ impl TextCtrl {
             return false;
         }
         unsafe { ffi::wxd_TextCtrl_IsEditable(ptr) }
+    }
+
+    /// Disables Cocoa's automatic smart quote/dash/substitution features for this
+    /// control (macOS only). Useful for fields where a user's literal input (a
+    /// straight quote, a plain hyphen) should not be silently "corrected".
+    /// No-op if the control has been destroyed, and a no-op on other platforms.
+    pub fn disable_all_smart_substitutions(&self) {
+        #[cfg(target_os = "macos")]
+        {
+            let ptr = self.textctrl_ptr();
+            if ptr.is_null() {
+                return;
+            }
+            unsafe { wxd_TextCtrl_DisableAllSmartSubstitutions(ptr) };
+        }
     }
 
     /// Gets the insertion point of the control.


### PR DESCRIPTION
## Summary
- Adds wxd_TextCtrl_DisableAllSmartSubstitutions (macOS only), wrapping wxTextCtrl::OSXDisableAllSmartSubstitutions, which is only declared on the OSX-specific wxTextCtrl header.
- Adds a disable_all_smart_substitutions method on the Rust TextCtrl widget, following the same manual-extern-declaration pattern used for the existing accessibility label helpers, since this symbol is guarded by #ifdef __WXOSX__ and invisible to bindgen.

## Motivation
Cocoa automatically substitutes straight quotes/hyphens for smart/curly variants in text fields unless a control opts out. For fields where a user's literal input should be preserved verbatim (search boxes, free text notes, and so on), this substitution is unwanted and currently cannot be disabled through wxDragon. wxWidgets already exposes OSXDisableAllSmartSubstitutions on the Cocoa port, it was just not wrapped yet.

## Test plan
- cargo build -p wxdragon succeeds locally.