### PR TITLE
Add OSXOnShouldTerminate and OSXOnWillTerminate quit hooks

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_app.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_app.h
@@ -96,6 +96,14 @@ WXD_EXPORTED void
 wxd_App_AddMacReopenAppHandler(wxd_App_t* app, wxd_MacReopenAppCallback callback, void* userData);
 WXD_EXPORTED void
 wxd_App_AddMacPrintFilesHandler(wxd_App_t* app, wxd_MacPrintFilesCallback callback, void* userData);
+// Handler runs on Quit (Cmd-Q, dock menu Quit, System Shut Down/Log Out). Returning
+// false from any registered handler vetoes termination.
+WXD_EXPORTED void
+wxd_App_AddMacShouldTerminateHandler(wxd_App_t* app, wxd_MacShouldTerminateCallback callback, void* userData);
+// Handler runs once termination has been confirmed and is about to proceed; use it
+// for last-chance cleanup, not to veto (that's what ShouldTerminate is for).
+WXD_EXPORTED void
+wxd_App_AddMacWillTerminateHandler(wxd_App_t* app, wxd_MacWillTerminateCallback callback, void* userData);
 
 // --- End of macOS-specific App Event Handlers ---
 

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -569,6 +569,9 @@ typedef void (*wxd_MacOpenURLCallback)(void* userData, const char* url);
 typedef void (*wxd_MacNewFileCallback)(void* userData);
 typedef void (*wxd_MacReopenAppCallback)(void* userData);
 typedef void (*wxd_MacPrintFilesCallback)(void* userData, const char** files, int count);
+// Return false to veto termination (e.g. Cmd-Q, dock menu Quit).
+typedef bool (*wxd_MacShouldTerminateCallback)(void* userData);
+typedef void (*wxd_MacWillTerminateCallback)(void* userData);
 
 // wxDragResult C Enum (for drag and drop operations)
 typedef enum {

--- a/rust/wxdragon-sys/cpp/src/app.cpp
+++ b/rust/wxdragon-sys/cpp/src/app.cpp
@@ -53,6 +53,10 @@ public:
     MacReopenApp() override;
     virtual void
     MacPrintFiles(const wxArrayString& fileNames) override;
+    virtual bool
+    OSXOnShouldTerminate() override;
+    virtual void
+    OSXOnWillTerminate() override;
 
     // Store multiple callbacks for each event type
     struct MacCallbackList {
@@ -61,6 +65,8 @@ public:
         std::vector<std::pair<wxd_MacNewFileCallback, void*>> newFile;
         std::vector<std::pair<wxd_MacReopenAppCallback, void*>> reopenApp;
         std::vector<std::pair<wxd_MacPrintFilesCallback, void*>> printFiles;
+        std::vector<std::pair<wxd_MacShouldTerminateCallback, void*>> shouldTerminate;
+        std::vector<std::pair<wxd_MacWillTerminateCallback, void*>> willTerminate;
     } m_macCallbacks;
 #endif
 };
@@ -615,6 +621,39 @@ WxdApp::MacPrintFiles(const wxArrayString& fileNames)
     }
 }
 
+// OSXOnShouldTerminate override - false from any registered handler vetoes termination
+bool
+WxdApp::OSXOnShouldTerminate()
+{
+    if (m_macCallbacks.shouldTerminate.empty()) {
+        return wxApp::OSXOnShouldTerminate();
+    }
+
+    bool shouldTerminate = true;
+    for (const auto& pair : m_macCallbacks.shouldTerminate) {
+        if (pair.first && !pair.first(pair.second)) {
+            shouldTerminate = false;
+        }
+    }
+    return shouldTerminate;
+}
+
+// OSXOnWillTerminate override - calls all registered handlers
+void
+WxdApp::OSXOnWillTerminate()
+{
+    if (m_macCallbacks.willTerminate.empty()) {
+        wxApp::OSXOnWillTerminate();
+        return;
+    }
+
+    for (const auto& pair : m_macCallbacks.willTerminate) {
+        if (pair.first) {
+            pair.first(pair.second);
+        }
+    }
+}
+
 #endif // __WXOSX__
 
 // Registration functions - add handlers to the callback lists
@@ -670,6 +709,28 @@ wxd_App_AddMacPrintFilesHandler(wxd_App_t* app, wxd_MacPrintFilesCallback callba
         return;
     WxdApp* wx_app = reinterpret_cast<WxdApp*>(app);
     wx_app->m_macCallbacks.printFiles.push_back(std::make_pair(callback, userData));
+#endif
+}
+
+void
+wxd_App_AddMacShouldTerminateHandler(wxd_App_t* app, wxd_MacShouldTerminateCallback callback, void* userData)
+{
+#ifdef __WXOSX__
+    if (!app || !callback)
+        return;
+    WxdApp* wx_app = reinterpret_cast<WxdApp*>(app);
+    wx_app->m_macCallbacks.shouldTerminate.push_back(std::make_pair(callback, userData));
+#endif
+}
+
+void
+wxd_App_AddMacWillTerminateHandler(wxd_App_t* app, wxd_MacWillTerminateCallback callback, void* userData)
+{
+#ifdef __WXOSX__
+    if (!app || !callback)
+        return;
+    WxdApp* wx_app = reinterpret_cast<WxdApp*>(app);
+    wx_app->m_macCallbacks.willTerminate.push_back(std::make_pair(callback, userData));
 #endif
 }
 

--- a/rust/wxdragon/src/app.rs
+++ b/rust/wxdragon/src/app.rs
@@ -511,9 +511,7 @@ impl crate::event::AppEvents for App {
             let callback = Box::new(callback);
             let user_data = Box::into_raw(callback) as *mut c_void;
 
-            unsafe {
-                ffi::wxd_App_AddMacWillTerminateHandler(self.handle, Some(mac_will_terminate_trampoline::<F>), user_data)
-            };
+            unsafe { ffi::wxd_App_AddMacWillTerminateHandler(self.handle, Some(mac_will_terminate_trampoline::<F>), user_data) };
         }
         #[cfg(not(target_os = "macos"))]
         {

--- a/rust/wxdragon/src/app.rs
+++ b/rust/wxdragon/src/app.rs
@@ -482,6 +482,44 @@ impl crate::event::AppEvents for App {
             let _ = callback;
         }
     }
+
+    fn on_should_terminate<F>(&self, callback: F)
+    where
+        F: Fn() -> bool + Send + 'static,
+    {
+        #[cfg(target_os = "macos")]
+        {
+            let callback = Box::new(callback);
+            let user_data = Box::into_raw(callback) as *mut c_void;
+
+            unsafe {
+                ffi::wxd_App_AddMacShouldTerminateHandler(self.handle, Some(mac_should_terminate_trampoline::<F>), user_data)
+            };
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = callback;
+        }
+    }
+
+    fn on_will_terminate<F>(&self, callback: F)
+    where
+        F: Fn() + Send + 'static,
+    {
+        #[cfg(target_os = "macos")]
+        {
+            let callback = Box::new(callback);
+            let user_data = Box::into_raw(callback) as *mut c_void;
+
+            unsafe {
+                ffi::wxd_App_AddMacWillTerminateHandler(self.handle, Some(mac_will_terminate_trampoline::<F>), user_data)
+            };
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = callback;
+        }
+    }
 }
 
 // Trampoline functions for macOS
@@ -572,6 +610,32 @@ where
     }
 
     callback(file_list);
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn mac_should_terminate_trampoline<F>(user_data: *mut c_void) -> bool
+where
+    F: Fn() -> bool + Send + 'static,
+{
+    if user_data.is_null() {
+        return true;
+    }
+
+    let callback = unsafe { &*(user_data as *const F) };
+    callback()
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn mac_will_terminate_trampoline<F>(user_data: *mut c_void)
+where
+    F: Fn() + Send + 'static,
+{
+    if user_data.is_null() {
+        return;
+    }
+
+    let callback = unsafe { &*(user_data as *const F) };
+    callback();
 }
 
 /// Runs the wxWidgets application main loop, providing a safe entry point.

--- a/rust/wxdragon/src/event/app_events.rs
+++ b/rust/wxdragon/src/event/app_events.rs
@@ -164,4 +164,36 @@ pub trait AppEvents {
     fn on_print_files<F>(&self, callback: F)
     where
         F: Fn(Vec<String>) + Send + 'static;
+
+    /// Binds a handler that runs when the user asks to quit the application
+    /// (Cmd-Q, the dock menu's Quit item, or the OS shutting down/logging out).
+    ///
+    /// Return `false` from the closure to veto termination. If multiple handlers
+    /// are registered, termination is vetoed if any of them returns `false`.
+    ///
+    /// # Arguments
+    /// * `callback` - A closure returning `true` to allow termination, `false` to veto it
+    ///
+    /// # Platform Support
+    /// - **macOS**: Fully supported
+    /// - **Windows**: No-op
+    /// - **Linux**: No-op
+    fn on_should_terminate<F>(&self, callback: F)
+    where
+        F: Fn() -> bool + Send + 'static;
+
+    /// Binds a handler that runs once termination has been confirmed and is about
+    /// to proceed. Use this for last-chance cleanup; it cannot veto termination
+    /// (use [`AppEvents::on_should_terminate`] for that).
+    ///
+    /// # Arguments
+    /// * `callback` - A closure that takes no arguments
+    ///
+    /// # Platform Support
+    /// - **macOS**: Fully supported
+    /// - **Windows**: No-op
+    /// - **Linux**: No-op
+    fn on_will_terminate<F>(&self, callback: F)
+    where
+        F: Fn() + Send + 'static;
 }


### PR DESCRIPTION
## Summary
- Adds wxd_App_AddMacShouldTerminateHandler and wxd_App_AddMacWillTerminateHandler, following the same multi-handler callback-vector pattern already used for MacOpenFiles, MacReopenApp, MacPrintFiles, and so on.
- OSXOnShouldTerminate is vetoable: if any registered handler returns false, termination is vetoed, matching the semantics of the underlying wxWidgets virtual.
- Adds on_should_terminate and on_will_terminate to the Rust AppEvents trait, following the same shape as the existing on_reopen_app/on_print_files methods (compiles on all platforms, no-op outside macOS).

## Motivation
wxApp::OSXOnShouldTerminate/OSXOnWillTerminate are the standard hooks for reacting to application termination on macOS (Cmd-Q, the dock menu's Quit item, system shutdown/log out). An app that needs to confirm a destructive in-progress action before quitting, or do last-chance cleanup, currently has no way to hook into this through wxDragon; only wxEVT_CLOSE_WINDOW on individual frames is available, which does not cover this path. wxWidgets already exposes both virtuals on the Cocoa port, they were just not wired up in the C or Rust binding layers yet.

## Test plan
- cargo build -p wxdragon succeeds locally.