### PR TITLE
Add EnableCloseButton, EnableMaximizeButton, EnableMinimizeButton to Frame

### DIFF
--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_frame.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_frame.h
@@ -68,6 +68,21 @@ wxd_Frame_ShowFullScreen(wxd_Frame_t* frame, bool show);
 WXD_EXPORTED bool
 wxd_Frame_IsFullScreen(wxd_Frame_t* frame);
 
+/// Enables or disables the title bar's close button/control, where the
+/// platform supports it (Windows, macOS). Returns false if not supported.
+WXD_EXPORTED bool
+wxd_Frame_EnableCloseButton(wxd_Frame_t* frame, bool enable);
+
+/// Enables or disables the title bar's maximize/zoom button/control, where
+/// the platform supports it (Windows, macOS). Returns false if not supported.
+WXD_EXPORTED bool
+wxd_Frame_EnableMaximizeButton(wxd_Frame_t* frame, bool enable);
+
+/// Enables or disables the title bar's minimize button/control, where the
+/// platform supports it (Windows, macOS). Returns false if not supported.
+WXD_EXPORTED bool
+wxd_Frame_EnableMinimizeButton(wxd_Frame_t* frame, bool enable);
+
 WXD_EXPORTED void
 wxd_Frame_SetIconFromBitmap(wxd_Frame_t* frame, const wxd_Bitmap_t* bitmap);
 

--- a/rust/wxdragon-sys/cpp/src/frame.cpp
+++ b/rust/wxdragon-sys/cpp/src/frame.cpp
@@ -217,6 +217,33 @@ wxd_Frame_IsFullScreen(wxd_Frame_t* frame)
     return false;
 }
 
+bool
+wxd_Frame_EnableCloseButton(wxd_Frame_t* frame, bool enable)
+{
+    if (frame) {
+        return ((wxFrame*)frame)->EnableCloseButton(enable);
+    }
+    return false;
+}
+
+bool
+wxd_Frame_EnableMaximizeButton(wxd_Frame_t* frame, bool enable)
+{
+    if (frame) {
+        return ((wxFrame*)frame)->EnableMaximizeButton(enable);
+    }
+    return false;
+}
+
+bool
+wxd_Frame_EnableMinimizeButton(wxd_Frame_t* frame, bool enable)
+{
+    if (frame) {
+        return ((wxFrame*)frame)->EnableMinimizeButton(enable);
+    }
+    return false;
+}
+
 void
 wxd_Frame_SetIconFromBitmap(wxd_Frame_t* frame, const wxd_Bitmap_t* bitmap)
 {

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -455,6 +455,39 @@ impl Frame {
         unsafe { ffi::wxd_Frame_IsFullScreen(ptr) }
     }
 
+    /// Enables or disables the title bar's close button/control, where the
+    /// platform supports it (Windows, macOS). Returns false if not supported,
+    /// or if the frame has been destroyed.
+    pub fn enable_close_button(&self, enable: bool) -> bool {
+        let ptr = self.frame_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_Frame_EnableCloseButton(ptr, enable) }
+    }
+
+    /// Enables or disables the title bar's maximize/zoom button/control,
+    /// where the platform supports it (Windows, macOS). Returns false if not
+    /// supported, or if the frame has been destroyed.
+    pub fn enable_maximize_button(&self, enable: bool) -> bool {
+        let ptr = self.frame_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_Frame_EnableMaximizeButton(ptr, enable) }
+    }
+
+    /// Enables or disables the title bar's minimize button/control, where
+    /// the platform supports it (Windows, macOS). Returns false if not
+    /// supported, or if the frame has been destroyed.
+    pub fn enable_minimize_button(&self, enable: bool) -> bool {
+        let ptr = self.frame_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_Frame_EnableMinimizeButton(ptr, enable) }
+    }
+
     /// Sets the frame's icon from a bitmap.
     /// The bitmap will be converted to an icon internally.
     /// No-op if the frame has been destroyed.


### PR DESCRIPTION
## Summary
- Adds wxd_Frame_EnableCloseButton, wxd_Frame_EnableMaximizeButton, and wxd_Frame_EnableMinimizeButton, wrapping the matching wxTopLevelWindow methods. These are generic (declared on wxTopLevelWindowBase, overridden on Windows/macOS/GTK), so this is not platform gated like the OSX-only wrappers, following the same shape as the existing ShowFullScreen/IsFullScreen addition.
- Adds enable_close_button, enable_maximize_button, and enable_minimize_button methods to the Rust Frame widget, each returning the underlying bool (false where the platform does not support disabling that button).

## Motivation
These let an app grey out individual title bar buttons, for example disabling Close on a window that must stay open until some in-progress action finishes, without having to hide the whole title bar or fight the window style flags. wxWidgets already exposes all three on Windows and the Cocoa port, they were just not wrapped yet.

## Test plan
- cargo build -p wxdragon succeeds locally.