### PR TITLE
Add FileSystemWatcher wrapping wxFileSystemWatcher

### DIFF
--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -123,6 +123,7 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/sound.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/timer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/accessible.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/fswatcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/about.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/activity_indicator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/animation_ctrl.cpp

--- a/rust/wxdragon-sys/cpp/include/core/wxd_fswatcher.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_fswatcher.h
@@ -1,0 +1,66 @@
+#ifndef WXD_FSWATCHER_H
+#define WXD_FSWATCHER_H
+
+#include "../wxd_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Creates a new file system watcher. Events are delivered to the watcher's own
+// event handler (bind to it directly with WXD_EVENT_TYPE_FSWATCHER), the same
+// way wxFileSystemWatcher behaves when SetOwner() is never called.
+WXD_EXPORTED wxd_FileSystemWatcher_t*
+wxd_FileSystemWatcher_Create(void);
+
+WXD_EXPORTED void
+wxd_FileSystemWatcher_Destroy(wxd_FileSystemWatcher_t* watcher);
+
+// Starts watching a single file or directory (non-recursive for directories).
+// `events` is a bitwise OR of WXDFSWEventCEnum values.
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_Add(wxd_FileSystemWatcher_t* watcher, const char* path, int events);
+
+// Starts watching a directory tree recursively.
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_AddTree(wxd_FileSystemWatcher_t* watcher, const char* path, int events);
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_Remove(wxd_FileSystemWatcher_t* watcher, const char* path);
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_RemoveTree(wxd_FileSystemWatcher_t* watcher, const char* path);
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_RemoveAll(wxd_FileSystemWatcher_t* watcher);
+
+// --- wxFileSystemWatcherEvent accessors ---
+// These operate on the wxd_Event_t delivered to a handler bound with
+// WXD_EVENT_TYPE_FSWATCHER; the caller is responsible for only calling them
+// from inside such a handler.
+
+// Bitwise OR of WXDFSWEventCEnum values describing what changed.
+WXD_EXPORTED int
+wxd_FileSystemWatcherEvent_GetChangeType(wxd_Event_t* event);
+
+// Caller-owned string (strdup'd); the Rust side reclaims it with CString::from_raw, matching wxd_Frame_GetTitle.
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetPath(wxd_Event_t* event);
+
+// For rename events, the new path; equal to GetPath() for other event kinds.
+// Caller-owned string (strdup'd); the Rust side reclaims it with CString::from_raw, matching wxd_Frame_GetTitle.
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetNewPath(wxd_Event_t* event);
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcherEvent_IsError(wxd_Event_t* event);
+
+// Caller-owned string (strdup'd); the Rust side reclaims it with CString::from_raw, matching wxd_Frame_GetTitle.
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetErrorDescription(wxd_Event_t* event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_FSWATCHER_H

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -363,6 +363,7 @@ typedef enum {
     WXD_EVENT_TYPE_PG_COL_DRAGGING = 402,      // wxEVT_PG_COL_DRAGGING
     WXD_EVENT_TYPE_PG_COL_END_DRAG = 403,      // wxEVT_PG_COL_END_DRAG
     WXD_EVENT_TYPE_MAGNIFY = 404,              // wxEVT_MAGNIFY
+    WXD_EVENT_TYPE_FSWATCHER = 407,            // wxEVT_FSWATCHER
 
     WXD_EVENT_TYPE_MAX // Keep this last for count if needed, or remove if not used for iteration
 } WXDEventTypeCEnum;
@@ -696,6 +697,25 @@ typedef struct wxd_StyledTextCtrl_t wxd_StyledTextCtrl_t;
 // AppProgressIndicator type
 typedef struct wxd_AppProgressIndicator_t wxd_AppProgressIndicator_t;
 typedef struct wxd_Sound_t wxd_Sound_t;
+
+/// Opaque pointer to wxFileSystemWatcher
+typedef struct wxd_FileSystemWatcher_t wxd_FileSystemWatcher_t;
+
+/// Kinds of change a wxd_FileSystemWatcher can report, matching wxFSW_EVENT_*.
+/// Combine with bitwise OR when calling wxd_FileSystemWatcher_Add/AddTree.
+typedef enum {
+    WXD_FSW_EVENT_CREATE = 0x01,
+    WXD_FSW_EVENT_DELETE = 0x02,
+    WXD_FSW_EVENT_RENAME = 0x04,
+    WXD_FSW_EVENT_MODIFY = 0x08,
+    WXD_FSW_EVENT_ACCESS = 0x10,
+    WXD_FSW_EVENT_ATTRIB = 0x20, // GTK only
+    WXD_FSW_EVENT_WARNING = 0x40,
+    WXD_FSW_EVENT_ERROR = 0x80,
+    WXD_FSW_EVENT_ALL = WXD_FSW_EVENT_CREATE | WXD_FSW_EVENT_DELETE | WXD_FSW_EVENT_RENAME |
+                        WXD_FSW_EVENT_MODIFY | WXD_FSW_EVENT_ACCESS | WXD_FSW_EVENT_ATTRIB |
+                        WXD_FSW_EVENT_WARNING | WXD_FSW_EVENT_ERROR
+} WXDFSWEventCEnum;
 
 // --- Appearance Support (wxWidgets 3.3.0+) ---
 

--- a/rust/wxdragon-sys/cpp/include/wxdragon.h
+++ b/rust/wxdragon-sys/cpp/include/wxdragon.h
@@ -117,6 +117,9 @@ extern "C" {
 // Timer
 #include "core/wxd_timer.h"
 
+// File system watcher
+#include "core/wxd_fswatcher.h"
+
 // Application progress indicator
 #include "core/wxd_appprogress.h"
 

--- a/rust/wxdragon-sys/cpp/src/core/fswatcher.cpp
+++ b/rust/wxdragon-sys/cpp/src/core/fswatcher.cpp
@@ -1,0 +1,114 @@
+#include <wx/wxprec.h>
+#include <wx/wx.h>
+#include "../../include/wxdragon.h"
+#include "../../include/core/wxd_fswatcher.h"
+#include <wx/fswatcher.h>
+
+extern "C" {
+
+WXD_EXPORTED wxd_FileSystemWatcher_t*
+wxd_FileSystemWatcher_Create(void)
+{
+    wxFileSystemWatcher* watcher = new wxFileSystemWatcher();
+    return reinterpret_cast<wxd_FileSystemWatcher_t*>(watcher);
+}
+
+WXD_EXPORTED void
+wxd_FileSystemWatcher_Destroy(wxd_FileSystemWatcher_t* watcher)
+{
+    if (!watcher)
+        return;
+    delete reinterpret_cast<wxFileSystemWatcher*>(watcher);
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_Add(wxd_FileSystemWatcher_t* watcher, const char* path, int events)
+{
+    if (!watcher || !path)
+        return false;
+    wxFileSystemWatcher* wx_watcher = reinterpret_cast<wxFileSystemWatcher*>(watcher);
+    return wx_watcher->Add(wxFileName(wxString::FromUTF8(path)), events);
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_AddTree(wxd_FileSystemWatcher_t* watcher, const char* path, int events)
+{
+    if (!watcher || !path)
+        return false;
+    wxFileSystemWatcher* wx_watcher = reinterpret_cast<wxFileSystemWatcher*>(watcher);
+    return wx_watcher->AddTree(wxFileName::DirName(wxString::FromUTF8(path)), events);
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_Remove(wxd_FileSystemWatcher_t* watcher, const char* path)
+{
+    if (!watcher || !path)
+        return false;
+    wxFileSystemWatcher* wx_watcher = reinterpret_cast<wxFileSystemWatcher*>(watcher);
+    return wx_watcher->Remove(wxFileName(wxString::FromUTF8(path)));
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_RemoveTree(wxd_FileSystemWatcher_t* watcher, const char* path)
+{
+    if (!watcher || !path)
+        return false;
+    wxFileSystemWatcher* wx_watcher = reinterpret_cast<wxFileSystemWatcher*>(watcher);
+    return wx_watcher->RemoveTree(wxFileName::DirName(wxString::FromUTF8(path)));
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcher_RemoveAll(wxd_FileSystemWatcher_t* watcher)
+{
+    if (!watcher)
+        return false;
+    wxFileSystemWatcher* wx_watcher = reinterpret_cast<wxFileSystemWatcher*>(watcher);
+    return wx_watcher->RemoveAll();
+}
+
+WXD_EXPORTED int
+wxd_FileSystemWatcherEvent_GetChangeType(wxd_Event_t* event)
+{
+    if (!event)
+        return 0;
+    wxFileSystemWatcherEvent* wx_event = reinterpret_cast<wxFileSystemWatcherEvent*>(event);
+    return wx_event->GetChangeType();
+}
+
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetPath(wxd_Event_t* event)
+{
+    if (!event)
+        return strdup("");
+    wxFileSystemWatcherEvent* wx_event = reinterpret_cast<wxFileSystemWatcherEvent*>(event);
+    return strdup(wx_event->GetPath().GetFullPath().ToUTF8().data());
+}
+
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetNewPath(wxd_Event_t* event)
+{
+    if (!event)
+        return strdup("");
+    wxFileSystemWatcherEvent* wx_event = reinterpret_cast<wxFileSystemWatcherEvent*>(event);
+    return strdup(wx_event->GetNewPath().GetFullPath().ToUTF8().data());
+}
+
+WXD_EXPORTED bool
+wxd_FileSystemWatcherEvent_IsError(wxd_Event_t* event)
+{
+    if (!event)
+        return false;
+    wxFileSystemWatcherEvent* wx_event = reinterpret_cast<wxFileSystemWatcherEvent*>(event);
+    return wx_event->IsError();
+}
+
+WXD_EXPORTED char*
+wxd_FileSystemWatcherEvent_GetErrorDescription(wxd_Event_t* event)
+{
+    if (!event)
+        return strdup("");
+    wxFileSystemWatcherEvent* wx_event = reinterpret_cast<wxFileSystemWatcherEvent*>(event);
+    return strdup(wx_event->GetErrorDescription().ToUTF8().data());
+}
+
+} // extern "C"

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -32,6 +32,7 @@
 #include <wx/menu.h> // NEW: For wxMenuEvent and wxEVT_MENU_* events
 #include <wx/taskbar.h> // Needed for wxEVT_TASKBAR_* constants
 #include <wx/timectrl.h> // ADDED: For wxTimePickerCtrl and wxEVT_TIME_CHANGED
+#include <wx/fswatcher.h> // ADDED: For wxEVT_FSWATCHER
 #if wxdUSE_MEDIACTRL
 #include <wx/mediactrl.h> // ADDED: For MediaCtrl events
 #endif
@@ -1013,6 +1014,8 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_MOUSEWHEEL;
     case WXD_EVENT_TYPE_MAGNIFY:
         return wxEVT_MAGNIFY;
+    case WXD_EVENT_TYPE_FSWATCHER:
+        return wxEVT_FSWATCHER;
 
     // TaskBarIcon events are handled later in this function (platform-specific support).
     case WXD_EVENT_TYPE_TASKBAR_CLICK:

--- a/rust/wxdragon/src/event/fswatcher_events.rs
+++ b/rust/wxdragon/src/event/fswatcher_events.rs
@@ -1,0 +1,124 @@
+//! Event system for `FileSystemWatcher`.
+
+use crate::event::{Event, EventType};
+use std::ffi::CString;
+use wxdragon_sys as ffi;
+
+/// Events specific to `FileSystemWatcher`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FSWatcherEvent {
+    /// Fired whenever a watched path changes (create, delete, rename, modify,
+    /// and so on), or when a warning/error occurs while watching.
+    Changed,
+}
+
+/// The kind of change a `FSWatcherEventData` describes, matching
+/// `wxFSW_EVENT_*`. Combine with bitwise OR when calling
+/// [`FileSystemWatcher::add`](crate::fswatcher::FileSystemWatcher::add) or
+/// [`add_tree`](crate::fswatcher::FileSystemWatcher::add_tree).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct FSWatcherEventKind(i32);
+
+impl FSWatcherEventKind {
+    pub const CREATE: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_CREATE as i32);
+    pub const DELETE: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_DELETE as i32);
+    pub const RENAME: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_RENAME as i32);
+    pub const MODIFY: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_MODIFY as i32);
+    /// GTK only.
+    pub const ACCESS: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_ACCESS as i32);
+    /// GTK only.
+    pub const ATTRIB: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_ATTRIB as i32);
+    pub const WARNING: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_WARNING as i32);
+    pub const ERROR: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_ERROR as i32);
+    pub const ALL: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_ALL as i32);
+
+    pub fn bits(self) -> i32 {
+        self.0
+    }
+
+    pub fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl std::ops::BitOr for FSWatcherEventKind {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// Event data for a `FileSystemWatcher` event.
+#[derive(Debug)]
+pub struct FSWatcherEventData {
+    event: Event,
+}
+
+impl FSWatcherEventData {
+    pub fn new(event: Event) -> Self {
+        Self { event }
+    }
+
+    /// What kind of change this event describes.
+    pub fn get_change_type(&self) -> FSWatcherEventKind {
+        let ptr = self.event._as_ptr();
+        if ptr.is_null() {
+            return FSWatcherEventKind(0);
+        }
+        FSWatcherEventKind(unsafe { ffi::wxd_FileSystemWatcherEvent_GetChangeType(ptr) })
+    }
+
+    /// The path the change occurred at.
+    pub fn get_path(&self) -> String {
+        let ptr = self.event._as_ptr();
+        if ptr.is_null() {
+            return String::new();
+        }
+        let c_str = unsafe { ffi::wxd_FileSystemWatcherEvent_GetPath(ptr) };
+        string_from_owned_c_str(c_str)
+    }
+
+    /// For rename events, the new path; equal to [`get_path`](Self::get_path)
+    /// for other event kinds.
+    pub fn get_new_path(&self) -> String {
+        let ptr = self.event._as_ptr();
+        if ptr.is_null() {
+            return String::new();
+        }
+        let c_str = unsafe { ffi::wxd_FileSystemWatcherEvent_GetNewPath(ptr) };
+        string_from_owned_c_str(c_str)
+    }
+
+    /// True if this event describes a warning or error rather than a change.
+    pub fn is_error(&self) -> bool {
+        let ptr = self.event._as_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_FileSystemWatcherEvent_IsError(ptr) }
+    }
+
+    /// Description of the warning/error, if [`is_error`](Self::is_error) is true.
+    pub fn get_error_description(&self) -> String {
+        let ptr = self.event._as_ptr();
+        if ptr.is_null() {
+            return String::new();
+        }
+        let c_str = unsafe { ffi::wxd_FileSystemWatcherEvent_GetErrorDescription(ptr) };
+        string_from_owned_c_str(c_str)
+    }
+}
+
+fn string_from_owned_c_str(ptr: *mut std::os::raw::c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    // SAFETY: the C side hands us a strdup'd string it no longer owns.
+    unsafe { CString::from_raw(ptr) }.to_string_lossy().into_owned()
+}
+
+// Use the macro to implement the trait
+crate::implement_category_event_handlers!(FSWatcherEvents, FSWatcherEvent, FSWatcherEventData,
+    Changed => fswatcher_change, EventType::FSWATCHER
+);

--- a/rust/wxdragon/src/event/fswatcher_events.rs
+++ b/rust/wxdragon/src/event/fswatcher_events.rs
@@ -18,8 +18,12 @@ pub enum FSWatcherEvent {
 /// [`add_tree`](crate::fswatcher::FileSystemWatcher::add_tree).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
+// The `as i32` casts below are unnecessary on MSVC (where C enums are already
+// `int`) but required on MinGW/GNU targets (where they default to `unsigned int`).
+#[allow(clippy::unnecessary_cast)]
 pub struct FSWatcherEventKind(i32);
 
+#[allow(clippy::unnecessary_cast)]
 impl FSWatcherEventKind {
     pub const CREATE: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_CREATE as i32);
     pub const DELETE: Self = Self(ffi::WXDFSWEventCEnum_WXD_FSW_EVENT_DELETE as i32);

--- a/rust/wxdragon/src/event/mod.rs
+++ b/rust/wxdragon/src/event/mod.rs
@@ -9,6 +9,7 @@ use wxdragon_sys as ffi;
 pub mod app_events;
 pub mod button_events;
 pub mod event_data;
+pub mod fswatcher_events;
 pub mod macros;
 pub mod menu_events;
 pub mod scroll_events;
@@ -33,6 +34,9 @@ pub use text_events::{TextEvent, TextEventData, TextEvents};
 
 // Re-export tree events for easier access
 pub use tree_events::{TreeEvent, TreeEventData, TreeEvents};
+
+// Re-export file system watcher events for easier access
+pub use fswatcher_events::{FSWatcherEvent, FSWatcherEventData, FSWatcherEventKind, FSWatcherEvents};
 
 // Re-export scroll events for easier access
 pub use scroll_events::{ScrollEvent, ScrollEventType, ScrollEvents};
@@ -122,6 +126,8 @@ pub struct EventType: ffi::WXDEventTypeCEnum { // Use the generated C enum type
     const MOTION = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOTION;
     const MOUSEWHEEL = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MOUSEWHEEL;
     const MAGNIFY = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_MAGNIFY;
+    /// Fired by a `FileSystemWatcher` for changes to a watched path.
+    const FSWATCHER = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_FSWATCHER;
     const ENTER_WINDOW = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_ENTER_WINDOW;
     const LEAVE_WINDOW = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_LEAVE_WINDOW;
     const KEY_DOWN = ffi::WXDEventTypeCEnum_WXD_EVENT_TYPE_KEY_DOWN;

--- a/rust/wxdragon/src/fswatcher.rs
+++ b/rust/wxdragon/src/fswatcher.rs
@@ -1,0 +1,124 @@
+//! File system watcher module for wxDragon.
+//!
+//! This module provides a safe wrapper around wxWidgets' `wxFileSystemWatcher`,
+//! which watches files and directories for changes using the native mechanism
+//! for each platform (FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW
+//! on Windows).
+
+use crate::event::{FSWatcherEventKind, WxEvtHandler};
+use std::ffi::CString;
+use wxdragon_sys as ffi;
+
+/// Watches files and directories for changes, delivering events for creation,
+/// deletion, renames, modification, and (where the platform supports it)
+/// access/attribute changes.
+///
+/// Bind a handler directly on the watcher with
+/// [`on_fswatcher_change`](crate::event::FSWatcherEvents::on_fswatcher_change);
+/// there is no separate "owner" to configure, unlike [`Timer`](crate::timer::Timer).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use wxdragon::prelude::*;
+/// use wxdragon::fswatcher::FileSystemWatcher;
+/// use wxdragon::event::FSWatcherEventKind;
+///
+/// let watcher = FileSystemWatcher::new();
+/// watcher.add("/path/to/watch", FSWatcherEventKind::ALL);
+/// watcher.on_fswatcher_change(|event| {
+///     println!("{:?}: {}", event.get_change_type(), event.get_path());
+/// });
+/// ```
+pub struct FileSystemWatcher {
+    ptr: *mut ffi::wxd_FileSystemWatcher_t,
+}
+
+impl FileSystemWatcher {
+    /// Creates a new, empty file system watcher. Add paths to watch with
+    /// [`add`](Self::add) or [`add_tree`](Self::add_tree).
+    pub fn new() -> Self {
+        let ptr = unsafe { ffi::wxd_FileSystemWatcher_Create() };
+        Self { ptr }
+    }
+
+    /// Starts watching a single file, or a directory non-recursively (only
+    /// direct children are reported, not files within subdirectories).
+    /// Returns false if the path could not be watched.
+    pub fn add(&self, path: &str, events: FSWatcherEventKind) -> bool {
+        if self.ptr.is_null() {
+            return false;
+        }
+        let Ok(c_path) = CString::new(path) else {
+            return false;
+        };
+        unsafe { ffi::wxd_FileSystemWatcher_Add(self.ptr, c_path.as_ptr(), events.bits()) }
+    }
+
+    /// Starts watching a directory tree recursively.
+    /// Returns false if the path could not be watched.
+    pub fn add_tree(&self, path: &str, events: FSWatcherEventKind) -> bool {
+        if self.ptr.is_null() {
+            return false;
+        }
+        let Ok(c_path) = CString::new(path) else {
+            return false;
+        };
+        unsafe { ffi::wxd_FileSystemWatcher_AddTree(self.ptr, c_path.as_ptr(), events.bits()) }
+    }
+
+    /// Stops watching a path previously passed to [`add`](Self::add).
+    pub fn remove(&self, path: &str) -> bool {
+        if self.ptr.is_null() {
+            return false;
+        }
+        let Ok(c_path) = CString::new(path) else {
+            return false;
+        };
+        unsafe { ffi::wxd_FileSystemWatcher_Remove(self.ptr, c_path.as_ptr()) }
+    }
+
+    /// Stops watching a directory tree previously passed to [`add_tree`](Self::add_tree).
+    pub fn remove_tree(&self, path: &str) -> bool {
+        if self.ptr.is_null() {
+            return false;
+        }
+        let Ok(c_path) = CString::new(path) else {
+            return false;
+        };
+        unsafe { ffi::wxd_FileSystemWatcher_RemoveTree(self.ptr, c_path.as_ptr()) }
+    }
+
+    /// Stops watching every path currently being watched.
+    pub fn remove_all(&self) -> bool {
+        if self.ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_FileSystemWatcher_RemoveAll(self.ptr) }
+    }
+}
+
+impl Default for FileSystemWatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for FileSystemWatcher {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe { ffi::wxd_FileSystemWatcher_Destroy(self.ptr) };
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}
+
+// wxFileSystemWatcherBase derives from wxEvtHandler and delivers events to
+// itself unless SetOwner() is called, so binding directly on the watcher works.
+impl WxEvtHandler for FileSystemWatcher {
+    unsafe fn get_event_handler_ptr(&self) -> *mut ffi::wxd_EvtHandler_t {
+        self.ptr as *mut ffi::wxd_EvtHandler_t
+    }
+}
+
+impl crate::event::FSWatcherEvents for FileSystemWatcher {}

--- a/rust/wxdragon/src/lib.rs
+++ b/rust/wxdragon/src/lib.rs
@@ -24,6 +24,7 @@ pub mod dnd;
 pub mod event;
 pub mod font;
 pub mod font_data;
+pub mod fswatcher;
 pub mod geometry;
 pub mod id;
 pub mod ipc;

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -14,10 +14,12 @@ pub use crate::datetime::DateTime;
 pub use crate::display::Display;
 pub use crate::event::{Event, EventType, IdleEvent, IdleMode, MouseWheelAxis, WindowEventData, WxEvtHandler};
 // ADDED: Event category traits
-pub use crate::event::{AppEvents, ButtonEvents, MenuEvents, ScrollEvents, TextEvents, TreeEvents, WindowEvents};
+pub use crate::event::{
+    AppEvents, ButtonEvents, FSWatcherEvents, MenuEvents, ScrollEvents, TextEvents, TreeEvents, WindowEvents,
+};
 // ADDED: Event Data Structs
 pub use crate::event::event_data::{CommandEventData, KeyEventData, MouseEventData};
-pub use crate::event::{IdleEventData, MenuEventData};
+pub use crate::event::{FSWatcherEventData, FSWatcherEventKind, IdleEventData, MenuEventData};
 pub use crate::geometry::{Point, Rect, Size};
 pub use crate::id::{ID_ANY, ID_APPLY, ID_CANCEL, ID_HELP, ID_HIGHEST, ID_NO, ID_OK, ID_YES, Id};
 pub use crate::language::Language;
@@ -233,6 +235,7 @@ pub use crate::printing::*;
 // --- Application & Misc ---
 // pub use crate::app::App; // Commented out as per previous error, App is in main or app module
 pub use crate::appprogress::AppProgressIndicator;
+pub use crate::fswatcher::FileSystemWatcher;
 pub use crate::ipc::{IPCClient, IPCConnection, IPCConnectionBuilder, IPCFormat, IPCServer};
 pub use crate::single_instance_checker::SingleInstanceChecker;
 pub use crate::timer::Timer;


### PR DESCRIPTION
## Summary
- Adds a wxd_FileSystemWatcher_t opaque type and C functions (Create, Destroy, Add, AddTree, Remove, RemoveTree, RemoveAll), wrapping wxFileSystemWatcher, which picks the native backend per platform (FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW on Windows, kqueue elsewhere).
- Adds a new WXD_EVENT_TYPE_FSWATCHER event type mapped to wxEVT_FSWATCHER, plus wxd_FileSystemWatcherEvent_* accessors for the change type, path, new path (for renames), and warning/error info carried by the event.
- Adds a WXDFSWEventCEnum enum matching wxFSW_EVENT_* for the events bitmask parameter.
- On the Rust side, adds a FileSystemWatcher type (owned, Drop-based, following the same shape as the existing Timer wrapper) plus a category event trait (FSWatcherEvents::on_fswatcher_change) generated with the existing implement_category_event_handlers macro, matching how ButtonEvents/TextEvents/TreeEvents already work.

## Design notes
wxFileSystemWatcherBase defaults its own event handler as the owner unless SetOwner() is called, so FileSystemWatcher implements WxEvtHandler directly (casting the watcher's own pointer to wxd_EvtHandler_t) and events are bound straight on the watcher object, no separate owner argument needed (unlike Timer, which really does require one on the wx side). SetOwner() itself is not exposed since the default behavior covers the common case; happy to add it if there's a use case for redirecting events elsewhere.

## Motivation
Watching a file or directory for external changes (an open document being edited by another program, a config file, a directory listing) is a common desktop app need with no cross-platform story otherwise. wxWidgets already provides this with native backends per platform, it just was not wrapped by wxDragon yet.

## Test plan
- cargo build -p wxdragon succeeds locally.