### PR TITLE
Add InfoBar and RichToolTip widgets, rework NotificationMessage backend selection

### DIFF
--- a/rust/wxdragon-sys/cpp/CMakeLists.txt
+++ b/rust/wxdragon-sys/cpp/CMakeLists.txt
@@ -188,6 +188,8 @@ set(WXDRAGON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/notebook.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/simplebook.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/notificationmessage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/infobar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/richtooltip.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/progressdialog.cpp

--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_adv_ui.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_adv_ui.h
@@ -1,43 +1,58 @@
-/* This is a new file */
 #ifndef WXD_ADV_UI_H
 #define WXD_ADV_UI_H
 
-#include "../wxdragon.h" // For WXD_EXPORTED, wxd_Window_t, etc.
+#include "../wxdragon.h"
 
-// --- NotificationMessage ---
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 WXD_EXPORTED wxd_NotificationMessage_t*
 wxd_NotificationMessage_Create(const char* title, const char* message,
-                               wxd_Window_t* parent, // Can be NULL
-                               int flags // wxICON_INFORMATION, wxICON_WARNING, wxICON_ERROR, or 0
-);
+                               wxd_Window_t* parent,
+                               int flags);
+
+WXD_EXPORTED wxd_NotificationMessage_t*
+wxd_NotificationMessage_CreateGeneric(const char* title, const char* message,
+                                      wxd_Window_t* parent,
+                                      int flags);
 
 WXD_EXPORTED void
 wxd_NotificationMessage_Destroy(wxd_NotificationMessage_t* self);
 
 WXD_EXPORTED bool
-wxd_NotificationMessage_Show(
-    wxd_NotificationMessage_t* self,
-    int timeout); // timeout: wxNOTIFY_TIMEOUT_AUTO, wxNOTIFY_TIMEOUT_NEVER, or ms
+wxd_NotificationMessage_Show(wxd_NotificationMessage_t* self, int timeout);
+
 WXD_EXPORTED bool
 wxd_NotificationMessage_Close(wxd_NotificationMessage_t* self);
 
 WXD_EXPORTED void
 wxd_NotificationMessage_SetTitle(wxd_NotificationMessage_t* self, const char* title);
+
 WXD_EXPORTED void
 wxd_NotificationMessage_SetMessage(wxd_NotificationMessage_t* self, const char* message);
+
 WXD_EXPORTED void
 wxd_NotificationMessage_SetFlags(wxd_NotificationMessage_t* self, int flags);
+
 WXD_EXPORTED void
 wxd_NotificationMessage_SetParent(wxd_NotificationMessage_t* self, wxd_Window_t* parent);
 
-// AddAction function
 WXD_EXPORTED bool
 wxd_NotificationMessage_AddAction(wxd_NotificationMessage_t* self, wxd_Id actionid,
                                   const char* label);
 
-// Event binding for wxNotificationMessage events (wxEVT_NOTIFICATION_MESSAGE_CLICK, etc.)
-// is handled by binding to a parent wxEvtHandler (e.g., the parent window or frame)
-// using the standard wxd_EvtHandler_Bind and the WXDEventTypeCEnum values for these events.
-// No specific wxd_NotificationMessage_BindClick etc. functions are needed on the notification object itself.
+WXD_EXPORTED bool
+wxd_NotificationMessage_MSWUseToasts(const char* shortcutPath, const char* appId);
+
+WXD_EXPORTED void
+wxd_NotificationMessage_UseTaskBarIcon(wxd_NotificationMessage_t* self, wxd_TaskBarIcon_t* icon);
+
+WXD_EXPORTED void
+wxd_NotificationMessage_SetIcon(wxd_NotificationMessage_t* self, const wxd_BitmapBundle_t* icon);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // WXD_ADV_UI_H

--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_infobar.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_infobar.h
@@ -1,0 +1,50 @@
+#ifndef WXD_INFOBAR_H
+#define WXD_INFOBAR_H
+
+#include "../wxdragon.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WXD_EXPORTED wxd_InfoBar_t*
+wxd_InfoBar_Create(wxd_Window_t* parent, wxd_Id id);
+
+WXD_EXPORTED void
+wxd_InfoBar_ShowMessage(wxd_InfoBar_t* self, const char* msg, int flags);
+
+WXD_EXPORTED void
+wxd_InfoBar_Dismiss(wxd_InfoBar_t* self);
+
+WXD_EXPORTED void
+wxd_InfoBar_AddButton(wxd_InfoBar_t* self, wxd_Id btnid, const char* label);
+
+WXD_EXPORTED void
+wxd_InfoBar_RemoveButton(wxd_InfoBar_t* self, wxd_Id btnid);
+
+WXD_EXPORTED void
+wxd_InfoBar_SetShowHideEffects(wxd_InfoBar_t* self, int showEffect, int hideEffect);
+
+WXD_EXPORTED int
+wxd_InfoBar_GetShowEffect(wxd_InfoBar_t* self);
+
+WXD_EXPORTED int
+wxd_InfoBar_GetHideEffect(wxd_InfoBar_t* self);
+
+WXD_EXPORTED void
+wxd_InfoBar_SetEffectDuration(wxd_InfoBar_t* self, int duration);
+
+WXD_EXPORTED int
+wxd_InfoBar_GetEffectDuration(wxd_InfoBar_t* self);
+
+WXD_EXPORTED size_t
+wxd_InfoBar_GetButtonCount(wxd_InfoBar_t* self);
+
+WXD_EXPORTED bool
+wxd_InfoBar_HasButtonId(wxd_InfoBar_t* self, wxd_Id btnid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_INFOBAR_H

--- a/rust/wxdragon-sys/cpp/include/widgets/wxd_richtooltip.h
+++ b/rust/wxdragon-sys/cpp/include/widgets/wxd_richtooltip.h
@@ -1,0 +1,41 @@
+#ifndef WXD_RICHTOOLTIP_H
+#define WXD_RICHTOOLTIP_H
+
+#include "../wxdragon.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WXD_EXPORTED wxd_RichToolTip_t*
+wxd_RichToolTip_Create(const char* title, const char* message);
+
+WXD_EXPORTED void
+wxd_RichToolTip_Destroy(wxd_RichToolTip_t* self);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetBackgroundColour(wxd_RichToolTip_t* self, const wxd_Colour_t* col, const wxd_Colour_t* colEnd);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTitleFont(wxd_RichToolTip_t* self, const wxd_Font_t* font);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetIcon(wxd_RichToolTip_t* self, int icon);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetCustomIcon(wxd_RichToolTip_t* self, const wxd_BitmapBundle_t* icon);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTimeout(wxd_RichToolTip_t* self, unsigned int milliseconds, unsigned int millisecondsShowdelay);
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTipKind(wxd_RichToolTip_t* self, int tipKind);
+
+WXD_EXPORTED void
+wxd_RichToolTip_ShowFor(wxd_RichToolTip_t* self, wxd_Window_t* win, const wxd_Rect* rect);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WXD_RICHTOOLTIP_H

--- a/rust/wxdragon-sys/cpp/include/wxd_types.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_types.h
@@ -455,6 +455,8 @@ typedef struct wxd_FilePickerCtrl_t wxd_FilePickerCtrl_t;
 typedef struct wxd_DirPickerCtrl_t wxd_DirPickerCtrl_t;
 typedef struct wxd_FontPickerCtrl_t wxd_FontPickerCtrl_t;
 typedef struct wxd_NotificationMessage_t wxd_NotificationMessage_t;
+typedef struct wxd_InfoBar_t wxd_InfoBar_t;
+typedef struct wxd_RichToolTip_t wxd_RichToolTip_t;
 typedef struct wxd_FileCtrl_t wxd_FileCtrl_t;
 typedef struct wxd_MediaCtrl_t wxd_MediaCtrl_t;
 typedef struct wxd_RearrangeList_t wxd_RearrangeList_t;

--- a/rust/wxdragon-sys/cpp/include/wxdragon.h
+++ b/rust/wxdragon-sys/cpp/include/wxdragon.h
@@ -111,6 +111,8 @@ extern "C" {
 #include "widgets/wxd_pickers.h"
 #include "widgets/wxd_file_ctrl.h"
 #include "widgets/wxd_adv_ui.h"          // For wxNotificationMessage etc.
+#include "widgets/wxd_infobar.h"
+#include "widgets/wxd_richtooltip.h"
 #include "widgets/wxd_editablelistbox.h" // For wxEditableListBox
 #include "widgets/wxd_aui.h"
 

--- a/rust/wxdragon-sys/cpp/src/aui_manager.cpp
+++ b/rust/wxdragon-sys/cpp/src/aui_manager.cpp
@@ -1,12 +1,12 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
 #include "../include/wxdragon.h"
+#if wxdUSE_AUI && wxUSE_AUI
 #include "wxd_utils.h"
 
 #include <wx/aui/framemanager.h>
 #include <wx/aui/auibook.h>
 
-// Direction constants for AddPane function (matching wxAUI constants)
 #define WXD_AUI_DOCK_LEFT   (0)
 #define WXD_AUI_DOCK_RIGHT  (1)
 #define WXD_AUI_DOCK_TOP    (2)
@@ -496,4 +496,6 @@ wxd_AuiPaneInfo_CaptionVisible(wxd_AuiPaneInfo_t* self, bool visible)
     return self;
 }
 
-} // extern "C"
+}
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/aui_mdi_child_frame.cpp
+++ b/rust/wxdragon-sys/cpp/src/aui_mdi_child_frame.cpp
@@ -1,6 +1,7 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
 #include "../include/wxdragon.h"
+#if wxdUSE_AUI && wxUSE_AUI
 #include <wx/aui/framemanager.h> // For wxAuiManager
 #include <wx/aui/auibook.h>      // For wxAuiNotebook
 #include <wx/aui/aui.h>          // For wxAuiPaneInfo etc. and wxAuiMDIChildFrame
@@ -31,3 +32,4 @@ wxd_AuiMDIChildFrame_Create(wxd_AuiMDIParentFrame_t* parent, int id, const char*
 
 // Implementations for other wxAuiMDIChildFrame specific functions will go here.
 }
+#endif

--- a/rust/wxdragon-sys/cpp/src/aui_mdi_parent_frame.cpp
+++ b/rust/wxdragon-sys/cpp/src/aui_mdi_parent_frame.cpp
@@ -1,13 +1,10 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
 #include "../include/wxdragon.h"
+#if wxdUSE_AUI && wxUSE_AUI
 #include <wx/aui/framemanager.h>
 #include <wx/aui/auibook.h>
 #include <wx/aui/aui.h>
-
-// Helper macro for string conversion, WXD_STR_TO_WX_STRING_UTF8_NULL_OK is available via wxd_utils.h in wxdragon.h
-// but can be defined locally if preferred or for standalone testing.
-// #define WXD_STR_TO_WX_STRING_UTF8_NULL_OK(str) (str ? wxString::FromUTF8(str) : wxString())
 
 extern "C" {
 
@@ -18,7 +15,6 @@ wxd_AuiMDIParentFrame_Create(wxd_Window_t* parent, int id, const char* title, wx
     wxWindow* parentPtr = (wxWindow*)parent;
     wxPoint wxPos = wxPoint(pos.x, pos.y);
     wxSize wxSizeInstance = wxSize(size.width, size.height);
-    // Use the macro from wxd_utils.h (included via wxdragon.h) for robust null handling and UTF-8 conversion.
     wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
     wxString wxName = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(name);
 
@@ -27,5 +23,6 @@ wxd_AuiMDIParentFrame_Create(wxd_Window_t* parent, int id, const char* title, wx
     return (wxd_AuiMDIParentFrame_t*)frame;
 }
 
-// Implementations for other wxAuiMDIParentFrame specific functions will go here.
 }
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/aui_notebook.cpp
+++ b/rust/wxdragon-sys/cpp/src/aui_notebook.cpp
@@ -1,12 +1,9 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
 #include "../include/wxdragon.h"
-#include <wx/aui/auibook.h> // For wxAuiNotebook
+#if wxdUSE_AUI && wxUSE_AUI
+#include <wx/aui/auibook.h>
 #include "wxd_utils.h"
-
-// Ensure this is part of wx/aui/auibook.h or wx/aui/aui.h
-// If wxAuiNotebook is in wx/aui/aui.h, this might need adjustment,
-// but typically dedicated controls are in their own headers like auibook.h
 
 extern "C" {
 
@@ -14,8 +11,6 @@ WXD_EXPORTED wxd_AuiNotebook_t*
 wxd_AuiNotebook_Create(wxd_Window_t* parent, int id, wxd_Point pos, wxd_Size size, int64_t style)
 {
     wxWindow* parentPtr = (wxWindow*)parent;
-    // Note: wxAuiNotebook parent can be null according to some docs, but safer to require for now.
-    // if (!parentPtr) return nullptr;
 
     wxPoint wxPos = wxPoint(pos.x, pos.y);
     wxSize wxSizeInstance = wxSize(size.width, size.height);
@@ -160,4 +155,6 @@ wxd_AuiNotebook_SetPageText(wxd_AuiNotebook_t* self, size_t page_idx, const char
     return notebook->SetPageText(page_idx, wxText);
 }
 
-} // extern "C"
+}
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/aui_toolbar.cpp
+++ b/rust/wxdragon-sys/cpp/src/aui_toolbar.cpp
@@ -1,14 +1,13 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
-#include "../include/wxdragon.h" // Main header for wxDragon C API
-#include <wx/aui/auibar.h>       // For wxAuiToolBar
-#include <wx/window.h>           // For wxWindow
-#include <wx/control.h>          // For wxControl
-#include <wx/string.h>           // For wxString
-#include <wx/gdicmn.h>           // For wxPoint, wxSize, wxID_ANY, etc.
-#include "wxd_utils.h"           // For WXD_STR_TO_WX_STRING_UTF8_NULL_OK, etc.
-
-// --- wxAuiToolBar ---
+#include "../include/wxdragon.h"
+#if wxdUSE_AUI && wxUSE_AUI
+#include <wx/aui/auibar.h>
+#include <wx/window.h>
+#include <wx/control.h>
+#include <wx/string.h>
+#include <wx/gdicmn.h>
+#include "wxd_utils.h"
 
 extern "C" {
 
@@ -16,10 +15,6 @@ WXD_EXPORTED wxd_AuiToolBar_t*
 wxd_AuiToolBar_Create(wxd_Window_t* parent, int id, wxd_Point pos, wxd_Size size, int64_t style)
 {
     wxWindow* wx_parent = (wxWindow*)parent;
-    // wxID_ANY is -1, which is a common default for id.
-    // wxDefaultPosition is wxPoint(-1, -1)
-    // wxDefaultSize is wxSize(-1, -1)
-    // style could be wxAUI_TB_DEFAULT_STYLE
     wxAuiToolBar* toolbar = new wxAuiToolBar(wx_parent, id, wxPoint(pos.x, pos.y),
                                              wxSize(size.width, size.height), style);
     return (wxd_AuiToolBar_t*)toolbar;
@@ -238,4 +233,6 @@ wxd_AuiToolBar_DeleteTool(wxd_AuiToolBar_t* self, int tool_id)
     return toolbar->DeleteTool(tool_id);
 }
 
-} // extern "C"
+}
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/event.cpp
+++ b/rust/wxdragon-sys/cpp/src/event.cpp
@@ -33,29 +33,29 @@
 #include <wx/taskbar.h> // Needed for wxEVT_TASKBAR_* constants
 #include <wx/timectrl.h> // ADDED: For wxTimePickerCtrl and wxEVT_TIME_CHANGED
 #include <wx/fswatcher.h> // ADDED: For wxEVT_FSWATCHER
-#if wxdUSE_MEDIACTRL
-#include <wx/mediactrl.h> // ADDED: For MediaCtrl events
+#if wxdUSE_MEDIACTRL && wxUSE_MEDIACTRL
+#include <wx/mediactrl.h>
 #endif
-#if wxdUSE_WEBVIEW
-#include <wx/webview.h> // ADDED: For WebView events
+#if wxdUSE_WEBVIEW && wxUSE_WEBVIEW
+#include <wx/webview.h>
 #endif
-#include <wx/dataview.h> // ADDED: For DataView events
+#include <wx/dataview.h>
 #include <wx/grid.h>
 #include <wx/propgrid/propgrid.h>
-#if wxdUSE_STC
-#include <wx/stc/stc.h> // ADDED: For StyledTextCtrl events
+#if wxdUSE_STC && wxUSE_STC
+#include <wx/stc/stc.h>
 #endif
-#include "../src/wxd_utils.h" // For WXD_STR_TO_WX_STRING_UTF8_NULL_OK, etc.
-#if wxdUSE_AUI
-#include <wx/aui/framemanager.h> // ADDED: For wxEVT_AUI_* constants
+#include "../src/wxd_utils.h"
+#if wxdUSE_AUI && wxUSE_AUI
+#include <wx/aui/framemanager.h>
 #endif
-#include <wx/dynarray.h> // For wxEVT_REARRANGE_LIST
+#include <wx/dynarray.h>
 #include <wx/log.h>
 #include <wx/utils.h>
-#include <wx/rearrangectrl.h> // ADDED: For wxEVT_REARRANGE_LIST
-#include <wx/collpane.h>      // ADDED: For wxEVT_COLLAPSIBLEPANE_CHANGED
-#if wxdUSE_RICHTEXT
-#include <wx/richtext/richtextctrl.h> // ADDED: For richtext events
+#include <wx/rearrangectrl.h>
+#include <wx/collpane.h>
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
+#include <wx/richtext/richtextctrl.h>
 #endif
 
 static inline std::string
@@ -140,7 +140,7 @@ IsVetableEventType(wxEventType eventType)
     }
 
 // AUI events
-#if wxdUSE_AUI
+#if wxdUSE_AUI && wxUSE_AUI
     if (eventType == wxEVT_AUI_PANE_CLOSE) {
         return true;
     }
@@ -1245,7 +1245,7 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_LIST_COL_BEGIN_DRAG;
 
 // Media events
-#if wxdUSE_MEDIACTRL
+#if wxdUSE_MEDIACTRL && wxUSE_MEDIACTRL
     case WXD_EVENT_TYPE_MEDIA_LOADED:
         return wxEVT_MEDIA_LOADED;
     case WXD_EVENT_TYPE_MEDIA_STOP:
@@ -1334,7 +1334,7 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_ANY;
 
 // AUI Manager event types
-#if wxdUSE_AUI
+#if wxdUSE_AUI && wxUSE_AUI
     case WXD_EVENT_TYPE_AUI_PANE_BUTTON:
         return wxEVT_AUI_PANE_BUTTON;
     case WXD_EVENT_TYPE_AUI_PANE_CLOSE:
@@ -1358,7 +1358,7 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
         return wxEVT_COLLAPSIBLEPANE_CHANGED;
 
 // StyledTextCtrl events - only available when stc feature is enabled
-#if wxdUSE_STC
+#if wxdUSE_STC && wxUSE_STC
     case WXD_EVENT_TYPE_STC_CHANGE:
         return wxEVT_STC_CHANGE;
     case WXD_EVENT_TYPE_STC_STYLENEEDED:
@@ -1418,7 +1418,7 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
 #endif
 
 // RichText events - only available when richtext feature is enabled
-#if wxdUSE_RICHTEXT
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
     case WXD_EVENT_TYPE_RICHTEXT_LEFT_CLICK:
         return wxEVT_RICHTEXT_LEFT_CLICK;
     case WXD_EVENT_TYPE_RICHTEXT_RIGHT_CLICK:
@@ -1477,7 +1477,7 @@ get_wx_event_type_for_c_enum(WXDEventTypeCEnum c_enum_val)
 #endif
 
 // WebView event types - only available when webview feature is enabled
-#if wxdUSE_WEBVIEW
+#if wxdUSE_WEBVIEW && wxUSE_WEBVIEW
     case WXD_EVENT_TYPE_WEBVIEW_CREATED:
         return wxEVT_WEBVIEW_CREATED;
     case WXD_EVENT_TYPE_WEBVIEW_NAVIGATING:

--- a/rust/wxdragon-sys/cpp/src/infobar.cpp
+++ b/rust/wxdragon-sys/cpp/src/infobar.cpp
@@ -1,0 +1,112 @@
+#include <wx/wxprec.h>
+#include <wx/wx.h>
+#include "../include/wxdragon.h"
+#if wxUSE_INFOBAR
+#include <wx/infobar.h>
+
+extern "C" {
+
+WXD_EXPORTED wxd_InfoBar_t*
+wxd_InfoBar_Create(wxd_Window_t* parent, wxd_Id id)
+{
+	wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
+	wxInfoBar* bar = new wxInfoBar(wxParent, id);
+	return reinterpret_cast<wxd_InfoBar_t*>(bar);
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_ShowMessage(wxd_InfoBar_t* self, const char* msg, int flags)
+{
+	if (!self)
+		return;
+	wxString wxMsg = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(msg);
+	reinterpret_cast<wxInfoBar*>(self)->ShowMessage(wxMsg, flags);
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_Dismiss(wxd_InfoBar_t* self)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxInfoBar*>(self)->Dismiss();
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_AddButton(wxd_InfoBar_t* self, wxd_Id btnid, const char* label)
+{
+	if (!self)
+		return;
+	wxString wxLabel = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(label);
+	reinterpret_cast<wxInfoBar*>(self)->AddButton(btnid, wxLabel);
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_RemoveButton(wxd_InfoBar_t* self, wxd_Id btnid)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxInfoBar*>(self)->RemoveButton(btnid);
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_SetShowHideEffects(wxd_InfoBar_t* self, int showEffect, int hideEffect)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxInfoBar*>(self)->SetShowHideEffects(
+		static_cast<wxShowEffect>(showEffect),
+		static_cast<wxShowEffect>(hideEffect)
+	);
+}
+
+WXD_EXPORTED int
+wxd_InfoBar_GetShowEffect(wxd_InfoBar_t* self)
+{
+	if (!self)
+		return 0;
+	return static_cast<int>(reinterpret_cast<wxInfoBar*>(self)->GetShowEffect());
+}
+
+WXD_EXPORTED int
+wxd_InfoBar_GetHideEffect(wxd_InfoBar_t* self)
+{
+	if (!self)
+		return 0;
+	return static_cast<int>(reinterpret_cast<wxInfoBar*>(self)->GetHideEffect());
+}
+
+WXD_EXPORTED void
+wxd_InfoBar_SetEffectDuration(wxd_InfoBar_t* self, int duration)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxInfoBar*>(self)->SetEffectDuration(duration);
+}
+
+WXD_EXPORTED int
+wxd_InfoBar_GetEffectDuration(wxd_InfoBar_t* self)
+{
+	if (!self)
+		return 0;
+	return reinterpret_cast<wxInfoBar*>(self)->GetEffectDuration();
+}
+
+WXD_EXPORTED size_t
+wxd_InfoBar_GetButtonCount(wxd_InfoBar_t* self)
+{
+	if (!self)
+		return 0;
+	return reinterpret_cast<wxInfoBar*>(self)->GetButtonCount();
+}
+
+WXD_EXPORTED bool
+wxd_InfoBar_HasButtonId(wxd_InfoBar_t* self, wxd_Id btnid)
+{
+	if (!self)
+		return false;
+	return reinterpret_cast<wxInfoBar*>(self)->HasButtonId(btnid);
+}
+
+}
+
+#endif // wxUSE_INFOBAR

--- a/rust/wxdragon-sys/cpp/src/notificationmessage.cpp
+++ b/rust/wxdragon-sys/cpp/src/notificationmessage.cpp
@@ -1,109 +1,158 @@
 #include <wx/wxprec.h>
 #include <wx/wx.h>
 #include "../include/wxdragon.h"
-#include <wx/notifmsg.h>         // Required for wxNotificationMessage
-#include <wx/generic/notifmsg.h> // Required for wxGenericNotificationMessage
+#include <wx/notifmsg.h>
+#include <wx/generic/notifmsg.h>
+#include <wx/bmpbndl.h>
+#if wxUSE_TASKBARICON
+#include <wx/taskbar.h>
+#endif
 
-// --- wxNotificationMessage ---
+extern "C" {
 
 WXD_EXPORTED wxd_NotificationMessage_t*
 wxd_NotificationMessage_Create(const char* title, const char* message, wxd_Window_t* parent,
                                int flags)
 {
-    wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
-    wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
-    wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
+	wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
+	wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
+	wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
 
-#ifdef __WXMSW__
-    // Use generic notifications on Windows to avoid taskbar icon issues
-    // that cause app hanging and persistent icons
-    wxGenericNotificationMessage* instance =
-        new wxGenericNotificationMessage(wxTitle, wxMessage, wxParent, flags);
-#else
-    // Use native notifications on other platforms
-    wxNotificationMessage* instance =
-        new wxNotificationMessage(wxTitle, wxMessage, wxParent, flags);
-#endif
+	wxNotificationMessage* instance =
+		new wxNotificationMessage(wxTitle, wxMessage, wxParent, flags);
 
-    return reinterpret_cast<wxd_NotificationMessage_t*>(instance);
+	return reinterpret_cast<wxd_NotificationMessage_t*>(instance);
+}
+
+WXD_EXPORTED wxd_NotificationMessage_t*
+wxd_NotificationMessage_CreateGeneric(const char* title, const char* message, wxd_Window_t* parent,
+                                      int flags)
+{
+	wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
+	wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
+	wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
+
+	wxGenericNotificationMessage* instance =
+		new wxGenericNotificationMessage(wxTitle, wxMessage, wxParent, flags);
+
+	return reinterpret_cast<wxd_NotificationMessage_t*>(instance);
 }
 
 WXD_EXPORTED void
 wxd_NotificationMessage_Destroy(wxd_NotificationMessage_t* self)
 {
-    if (self) {
-        // wxNotificationMessage is not a wxWindow, so it needs to be deleted directly.
-        // It does not have a Destroy() method that wxWindow objects use for deferred deletion.
-        delete reinterpret_cast<wxNotificationMessage*>(self);
-    }
+	if (self) {
+		delete reinterpret_cast<wxNotificationMessageBase*>(self);
+	}
 }
 
 WXD_EXPORTED bool
 wxd_NotificationMessage_Show(wxd_NotificationMessage_t* self, int timeout)
 {
-    if (!self)
-        return false;
-    // wxNotificationMessage::Show can take wxNotificationMessage::Timeout_Auto or wxNotificationMessage::Timeout_Never
-    // or a duration in seconds.
-    return reinterpret_cast<wxNotificationMessage*>(self)->Show(timeout);
+	if (!self)
+		return false;
+	return reinterpret_cast<wxNotificationMessageBase*>(self)->Show(timeout);
 }
 
 WXD_EXPORTED bool
 wxd_NotificationMessage_Close(wxd_NotificationMessage_t* self)
 {
-    if (!self)
-        return false;
-    return reinterpret_cast<wxNotificationMessage*>(self)->Close();
+	if (!self)
+		return false;
+	return reinterpret_cast<wxNotificationMessageBase*>(self)->Close();
 }
 
 WXD_EXPORTED void
 wxd_NotificationMessage_SetTitle(wxd_NotificationMessage_t* self, const char* title)
 {
-    if (!self)
-        return;
-    wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
-    reinterpret_cast<wxNotificationMessage*>(self)->SetTitle(wxTitle);
+	if (!self)
+		return;
+	wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
+	reinterpret_cast<wxNotificationMessageBase*>(self)->SetTitle(wxTitle);
 }
 
 WXD_EXPORTED void
 wxd_NotificationMessage_SetMessage(wxd_NotificationMessage_t* self, const char* message)
 {
-    if (!self)
-        return;
-    wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
-    reinterpret_cast<wxNotificationMessage*>(self)->SetMessage(wxMessage);
+	if (!self)
+		return;
+	wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
+	reinterpret_cast<wxNotificationMessageBase*>(self)->SetMessage(wxMessage);
 }
 
 WXD_EXPORTED void
 wxd_NotificationMessage_SetFlags(wxd_NotificationMessage_t* self, int flags)
 {
-    if (!self)
-        return;
-    reinterpret_cast<wxNotificationMessage*>(self)->SetFlags(flags);
+	if (!self)
+		return;
+	reinterpret_cast<wxNotificationMessageBase*>(self)->SetFlags(flags);
 }
 
 WXD_EXPORTED void
 wxd_NotificationMessage_SetParent(wxd_NotificationMessage_t* self, wxd_Window_t* parent)
 {
-    if (!self)
-        return;
-    wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
-    reinterpret_cast<wxNotificationMessage*>(self)->SetParent(wxParent);
+	if (!self)
+		return;
+	wxWindow* wxParent = parent ? reinterpret_cast<wxWindow*>(parent) : nullptr;
+	reinterpret_cast<wxNotificationMessageBase*>(self)->SetParent(wxParent);
 }
 
 WXD_EXPORTED bool
 wxd_NotificationMessage_AddAction(wxd_NotificationMessage_t* self, wxd_Id actionid,
                                   const char* label)
 {
-    if (!self)
-        return false;
-    wxString wxLabel = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(label);
-    return reinterpret_cast<wxNotificationMessage*>(self)->AddAction(actionid, wxLabel);
+	if (!self)
+		return false;
+	wxString wxLabel = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(label);
+	return reinterpret_cast<wxNotificationMessageBase*>(self)->AddAction(actionid, wxLabel);
 }
 
-// Event binding for wxNotificationMessage: Events like wxEVT_NOTIFICATION_MESSAGE_CLICK,
-// wxEVT_NOTIFICATION_MESSAGE_DISMISSED, and wxEVT_NOTIFICATION_MESSAGE_ACTION are command events.
-// They are typically handled by a wxEvtHandler (e.g., a parent window) that binds to these event types.
-// The wxd_EvtHandler_Bind function in event.cpp, along with the corresponding WXDEventTypeCEnum values,
-// is used for this purpose. No specific binding functions on wxNotificationMessage itself are needed.
-// The AddAction C API function has been implemented above.
+WXD_EXPORTED bool
+wxd_NotificationMessage_MSWUseToasts(const char* shortcutPath, const char* appId)
+{
+#ifdef __WXMSW__
+	wxString path = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(shortcutPath);
+	wxString id = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(appId);
+	return wxNotificationMessage::MSWUseToasts(path, id);
+#else
+	(void)shortcutPath;
+	(void)appId;
+	return false;
+#endif
+}
+
+WXD_EXPORTED void
+wxd_NotificationMessage_UseTaskBarIcon(wxd_NotificationMessage_t* self, wxd_TaskBarIcon_t* icon)
+{
+	if (!self)
+		return;
+#ifdef __WXMSW__
+	// UseTaskBarIcon is only present on the native wxNotificationMessage, not on
+	// wxGenericNotificationMessage (an unrelated sibling class with a different object
+	// layout). Use dynamic_cast rather than reinterpret_cast so calling this on a
+	// generic-backed notification (created via wxd_NotificationMessage_CreateGeneric)
+	// is a safe no-op instead of undefined behavior.
+	wxTaskBarIcon* tb = icon ? reinterpret_cast<wxTaskBarIcon*>(icon) : nullptr;
+	wxNotificationMessage* native =
+		dynamic_cast<wxNotificationMessage*>(reinterpret_cast<wxNotificationMessageBase*>(self));
+	if (native) {
+		native->UseTaskBarIcon(tb);
+	}
+#else
+	(void)icon;
+#endif
+}
+
+WXD_EXPORTED void
+wxd_NotificationMessage_SetIcon(wxd_NotificationMessage_t* self, const wxd_BitmapBundle_t* icon)
+{
+	if (!self)
+		return;
+	if (icon) {
+		const wxBitmapBundle* bundle = reinterpret_cast<const wxBitmapBundle*>(icon);
+		wxIcon icon_obj = bundle->GetIcon(wxDefaultSize);
+		reinterpret_cast<wxNotificationMessageBase*>(self)->SetIcon(icon_obj);
+	}
+}
+
+}

--- a/rust/wxdragon-sys/cpp/src/richtextctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/richtextctrl.cpp
@@ -4,8 +4,9 @@
 #include "wx/wx.h"
 #endif
 
-#include "wx/richtext/richtextctrl.h"
 #include "wxdragon.h"
+#if wxUSE_RICHTEXT
+#include "wx/richtext/richtextctrl.h"
 #include "wxd_utils.h"
 
 extern "C" {
@@ -504,4 +505,6 @@ wxd_RichTextCtrl_SetBackgroundColorSelection(wxd_RichTextCtrl_t* self, wxd_Colou
     return ctrl->SetStyle(wxRichTextRange(from, to), attr);
 }
 
-} // extern "C"
+}
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/richtooltip.cpp
+++ b/rust/wxdragon-sys/cpp/src/richtooltip.cpp
@@ -1,0 +1,96 @@
+#include <wx/wxprec.h>
+#include <wx/wx.h>
+#include "../include/wxdragon.h"
+#if wxUSE_RICHTOOLTIP
+#include <wx/richtooltip.h>
+#include <wx/bmpbndl.h>
+#include "wxd_utils.h"
+
+extern "C" {
+
+WXD_EXPORTED wxd_RichToolTip_t*
+wxd_RichToolTip_Create(const char* title, const char* message)
+{
+	wxString wxTitle = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(title);
+	wxString wxMessage = WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message);
+	wxRichToolTip* tip = new wxRichToolTip(wxTitle, wxMessage);
+	return reinterpret_cast<wxd_RichToolTip_t*>(tip);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_Destroy(wxd_RichToolTip_t* self)
+{
+	if (self) {
+		delete reinterpret_cast<wxRichToolTip*>(self);
+	}
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetBackgroundColour(wxd_RichToolTip_t* self, const wxd_Colour_t* col, const wxd_Colour_t* colEnd)
+{
+	if (!self || !col)
+		return;
+	wxColour c1(col->r, col->g, col->b, col->a);
+	wxColour c2 = colEnd ? wxColour(colEnd->r, colEnd->g, colEnd->b, colEnd->a) : wxColour();
+	reinterpret_cast<wxRichToolTip*>(self)->SetBackgroundColour(c1, c2);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTitleFont(wxd_RichToolTip_t* self, const wxd_Font_t* font)
+{
+	if (!self || !font)
+		return;
+	const wxFont* f = reinterpret_cast<const wxFont*>(font);
+	reinterpret_cast<wxRichToolTip*>(self)->SetTitleFont(*f);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetIcon(wxd_RichToolTip_t* self, int icon)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxRichToolTip*>(self)->SetIcon(icon);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetCustomIcon(wxd_RichToolTip_t* self, const wxd_BitmapBundle_t* icon)
+{
+	if (!self || !icon)
+		return;
+	const wxBitmapBundle* bundle = reinterpret_cast<const wxBitmapBundle*>(icon);
+	reinterpret_cast<wxRichToolTip*>(self)->SetIcon(*bundle);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTimeout(wxd_RichToolTip_t* self, unsigned int milliseconds, unsigned int millisecondsShowdelay)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxRichToolTip*>(self)->SetTimeout(milliseconds, millisecondsShowdelay);
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_SetTipKind(wxd_RichToolTip_t* self, int tipKind)
+{
+	if (!self)
+		return;
+	reinterpret_cast<wxRichToolTip*>(self)->SetTipKind(static_cast<wxTipKind>(tipKind));
+}
+
+WXD_EXPORTED void
+wxd_RichToolTip_ShowFor(wxd_RichToolTip_t* self, wxd_Window_t* win, const wxd_Rect* rect)
+{
+	if (!self || !win)
+		return;
+	wxWindow* w = reinterpret_cast<wxWindow*>(win);
+	if (rect) {
+		wxRect r(rect->x, rect->y, rect->width, rect->height);
+		reinterpret_cast<wxRichToolTip*>(self)->ShowFor(w, &r);
+	} else {
+		reinterpret_cast<wxRichToolTip*>(self)->ShowFor(w);
+	}
+}
+
+}
+
+#endif // wxUSE_RICHTOOLTIP

--- a/rust/wxdragon-sys/cpp/src/styledtextctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/styledtextctrl.cpp
@@ -4,8 +4,9 @@
 #include "wx/wx.h"
 #endif
 
-#include "wx/stc/stc.h"
 #include "../include/wxdragon.h"
+#if wxUSE_STC
+#include "wx/stc/stc.h"
 #include "wxd_utils.h"
 
 extern "C" {
@@ -1211,4 +1212,6 @@ wxd_StyledTextCtrl_GetWrapMode(wxd_StyledTextCtrl_t* self)
     return 0;
 }
 
-} // extern "C"
+}
+
+#endif

--- a/rust/wxdragon-sys/cpp/src/window.cpp
+++ b/rust/wxdragon-sys/cpp/src/window.cpp
@@ -13,12 +13,12 @@
 #include <wx/menu.h>     // For wxCommandEvent wxEVT_MENU
 
 // Conditional includes for optional features
-#if wxdUSE_RICHTEXT
-#include <wx/richtext/richtextctrl.h> // For wxRichTextCtrl scrolling
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
+#include <wx/richtext/richtextctrl.h>
 #endif
 
-#if wxdUSE_STC
-#include <wx/stc/stc.h> // For wxStyledTextCtrl scrolling
+#if wxdUSE_STC && wxUSE_STC
+#include <wx/stc/stc.h>
 #endif
 
 extern "C" {
@@ -838,7 +838,7 @@ wxd_Window_ShowPosition(wxd_Window_t* window, int64_t position)
     }
 
     // Try to cast to wxRichTextCtrl if richtext feature is enabled
-#if wxdUSE_RICHTEXT
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
     if (wxRichTextCtrl* rich_text = wxDynamicCast(wx_window, wxRichTextCtrl)) {
         rich_text->ShowPosition(static_cast<long>(position));
         return;
@@ -846,7 +846,7 @@ wxd_Window_ShowPosition(wxd_Window_t* window, int64_t position)
 #endif
 
     // Try to cast to wxStyledTextCtrl if STC feature is enabled
-#if wxdUSE_STC
+#if wxdUSE_STC && wxUSE_STC
     if (wxStyledTextCtrl* stc = wxDynamicCast(wx_window, wxStyledTextCtrl)) {
         stc->GotoPos(static_cast<int>(position));
         stc->EnsureCaretVisible();
@@ -867,7 +867,7 @@ wxd_Window_ScrollIntoView(wxd_Window_t* window, int64_t position, int keyCode)
     }
 
     // Try to cast to wxRichTextCtrl first (has the most sophisticated scrolling)
-#if wxdUSE_RICHTEXT
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
     if (wxRichTextCtrl* rich_text = wxDynamicCast(wx_window, wxRichTextCtrl)) {
         rich_text->ScrollIntoView(static_cast<long>(position), keyCode);
         return;
@@ -881,7 +881,7 @@ wxd_Window_ScrollIntoView(wxd_Window_t* window, int64_t position, int keyCode)
     }
 
     // For StyledTextCtrl, use position scrolling
-#if wxdUSE_STC
+#if wxdUSE_STC && wxUSE_STC
     if (wxStyledTextCtrl* stc = wxDynamicCast(wx_window, wxStyledTextCtrl)) {
         stc->GotoPos(static_cast<int>(position));
         stc->EnsureCaretVisible();
@@ -902,7 +902,7 @@ wxd_Window_IsPositionVisible(wxd_Window_t* window, int64_t position)
     }
 
     // Try to cast to wxRichTextCtrl first (has native support for this)
-#if wxdUSE_RICHTEXT
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
     if (wxRichTextCtrl* rich_text = wxDynamicCast(wx_window, wxRichTextCtrl)) {
         return rich_text->IsPositionVisible(static_cast<long>(position));
     }
@@ -928,7 +928,7 @@ wxd_Window_IsPositionVisible(wxd_Window_t* window, int64_t position)
     }
 
     // For StyledTextCtrl, check if position is visible
-#if wxdUSE_STC
+#if wxdUSE_STC && wxUSE_STC
     if (wxStyledTextCtrl* stc = wxDynamicCast(wx_window, wxStyledTextCtrl)) {
         int line = stc->LineFromPosition(static_cast<int>(position));
         int first_visible_line = stc->GetFirstVisibleLine();
@@ -955,14 +955,14 @@ wxd_Window_GetLastPosition(wxd_Window_t* window)
     }
 
     // Try to cast to wxRichTextCtrl
-#if wxdUSE_RICHTEXT
+#if wxdUSE_RICHTEXT && wxUSE_RICHTEXT
     if (wxRichTextCtrl* rich_text = wxDynamicCast(wx_window, wxRichTextCtrl)) {
         return static_cast<int64_t>(rich_text->GetLastPosition());
     }
 #endif
 
     // Try to cast to wxStyledTextCtrl
-#if wxdUSE_STC
+#if wxdUSE_STC && wxUSE_STC
     if (wxStyledTextCtrl* stc = wxDynamicCast(wx_window, wxStyledTextCtrl)) {
         return static_cast<int64_t>(stc->GetLength());
     }

--- a/rust/wxdragon/src/prelude.rs
+++ b/rust/wxdragon/src/prelude.rs
@@ -132,6 +132,7 @@ pub use crate::widgets::list_ctrl::{
     // Events for ListCtrl are now in list_ctrl/event.rs, re-exported from list_ctrl/mod.rs
 }; // Added Events
 
+pub use crate::widgets::info_bar::{InfoBar, InfoBarBuilder, InfoBarStyle, ShowEffect};
 pub use crate::widgets::list_ctrl::image_list_type;
 pub use crate::widgets::listbox::{ListBox, ListBoxBuilder, ListBoxStyle};
 pub use crate::widgets::mdi_child_frame::{MDIChildFrame, MDIChildFrameBuilder};
@@ -140,13 +141,8 @@ pub use crate::widgets::mdi_parent_frame::{MDIParentFrame, MDIParentFrameBuilder
 pub use crate::widgets::media_ctrl::{MediaCtrl, MediaCtrlBuilder, MediaCtrlPlayerControls, MediaState};
 pub use crate::widgets::notebook::{Notebook, NotebookBuilder, NotebookStyle};
 pub use crate::widgets::notification_message::{
-    NotificationMessage,
-    NotificationMessageBuilder,
-    NotificationStyle,
-    // Events for NotificationMessage are now in notification_message/event.rs, re-exported from notification_message/mod.rs
-    TIMEOUT_AUTO,
-    TIMEOUT_NEVER,
-}; // Added Events
+    NotificationMessage, NotificationMessageBuilder, NotificationStyle, TIMEOUT_AUTO, TIMEOUT_NEVER,
+};
 pub use crate::widgets::panel::{Panel, PanelBuilder, PanelStyle};
 pub use crate::widgets::property_grid::{
     Property, PropertyChoice, PropertyGrid, PropertyGridBuilder, PropertyGridEvent, PropertyGridEventData, PropertyGridStyle,
@@ -154,8 +150,8 @@ pub use crate::widgets::property_grid::{
 };
 pub use crate::widgets::radio_button::{RadioButton, RadioButtonBuilder, RadioButtonStyle};
 pub use crate::widgets::radiobox::{RadioBox, RadioBoxBuilder, RadioBoxStyle};
-// Added RearrangeList
 pub use crate::widgets::rearrangelist::{RearrangeList, RearrangeListBuilder, RearrangeListStyle};
+pub use crate::widgets::rich_tool_tip::{RichToolTip, RichToolTipBuilder, TipKind};
 #[cfg(feature = "richtext")]
 pub use crate::widgets::richtextctrl::{
     RichTextCtrl, RichTextCtrlBuilder, RichTextCtrlEvent, RichTextCtrlEventData, RichTextCtrlStyle, RichTextFileType,

--- a/rust/wxdragon/src/widgets/info_bar.rs
+++ b/rust/wxdragon/src/widgets/info_bar.rs
@@ -1,0 +1,261 @@
+use crate::event::{EventType, WxEvtHandler};
+use crate::id::Id;
+use crate::window::{WindowHandle, WxWidget};
+use std::ffi::CString;
+use wxdragon_sys as ffi;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(i32)]
+pub enum ShowEffect {
+    #[default]
+    None = 0,
+    RollToLeft = 1,
+    RollToRight = 2,
+    RollToTop = 3,
+    RollToBottom = 4,
+    SlideToLeft = 5,
+    SlideToRight = 6,
+    SlideToTop = 7,
+    SlideToBottom = 8,
+    Blend = 9,
+    Expand = 10,
+}
+
+impl ShowEffect {
+    pub fn from_i32(val: i32) -> Self {
+        match val {
+            1 => ShowEffect::RollToLeft,
+            2 => ShowEffect::RollToRight,
+            3 => ShowEffect::RollToTop,
+            4 => ShowEffect::RollToBottom,
+            5 => ShowEffect::SlideToLeft,
+            6 => ShowEffect::SlideToRight,
+            7 => ShowEffect::SlideToTop,
+            8 => ShowEffect::SlideToBottom,
+            9 => ShowEffect::Blend,
+            10 => ShowEffect::Expand,
+            _ => ShowEffect::None,
+        }
+    }
+}
+
+widget_style_enum!(
+    name: InfoBarStyle,
+    doc: "Style flags for InfoBar.",
+    variants: {
+        None: 0, "No icon.",
+        Information: ffi::WXD_ICON_INFORMATION, "Information icon.",
+        Warning: ffi::WXD_ICON_WARNING, "Warning icon.",
+        Error: ffi::WXD_ICON_ERROR, "Error icon.",
+        Question: ffi::WXD_ICON_QUESTION, "Question icon."
+    },
+    default_variant: Information
+);
+
+pub type RawInfoBar = ffi::wxd_InfoBar_t;
+
+#[derive(Clone, Copy)]
+pub struct InfoBar {
+    handle: WindowHandle,
+}
+
+impl InfoBar {
+    pub fn builder(parent: &dyn WxWidget) -> InfoBarBuilder<'_> {
+        InfoBarBuilder::new(parent)
+    }
+
+    #[inline]
+    fn info_bar_ptr(&self) -> *mut RawInfoBar {
+        self.handle
+            .get_ptr()
+            .map(|p| p as *mut RawInfoBar)
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    pub fn show_message(&self, msg: &str, flags: InfoBarStyle) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        let c_msg = CString::new(msg).unwrap_or_default();
+        unsafe {
+            ffi::wxd_InfoBar_ShowMessage(ptr, c_msg.as_ptr(), flags.bits() as i32);
+        }
+    }
+
+    pub fn dismiss(&self) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            ffi::wxd_InfoBar_Dismiss(ptr);
+        }
+    }
+
+    pub fn add_button(&self, btn_id: i32, label: &str) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        let c_label = CString::new(label).unwrap_or_default();
+        unsafe {
+            ffi::wxd_InfoBar_AddButton(ptr, btn_id, c_label.as_ptr());
+        }
+    }
+
+    pub fn remove_button(&self, btn_id: i32) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            ffi::wxd_InfoBar_RemoveButton(ptr, btn_id);
+        }
+    }
+
+    pub fn set_show_hide_effects(&self, show_effect: ShowEffect, hide_effect: ShowEffect) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            ffi::wxd_InfoBar_SetShowHideEffects(ptr, show_effect as i32, hide_effect as i32);
+        }
+    }
+
+    pub fn get_show_effect(&self) -> ShowEffect {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return ShowEffect::None;
+        }
+        ShowEffect::from_i32(unsafe { ffi::wxd_InfoBar_GetShowEffect(ptr) })
+    }
+
+    pub fn get_hide_effect(&self) -> ShowEffect {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return ShowEffect::None;
+        }
+        ShowEffect::from_i32(unsafe { ffi::wxd_InfoBar_GetHideEffect(ptr) })
+    }
+
+    pub fn set_effect_duration(&self, duration: i32) {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            ffi::wxd_InfoBar_SetEffectDuration(ptr, duration);
+        }
+    }
+
+    pub fn get_effect_duration(&self) -> i32 {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_InfoBar_GetEffectDuration(ptr) }
+    }
+
+    pub fn get_button_count(&self) -> usize {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ffi::wxd_InfoBar_GetButtonCount(ptr) }
+    }
+
+    pub fn has_button_id(&self, btn_id: i32) -> bool {
+        let ptr = self.info_bar_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+        unsafe { ffi::wxd_InfoBar_HasButtonId(ptr, btn_id) }
+    }
+
+    pub fn on_button<F>(&self, handler: F)
+    where
+        F: FnMut(crate::event::Event) + 'static,
+    {
+        self.bind_internal(EventType::COMMAND_BUTTON_CLICKED, handler);
+    }
+
+    pub(crate) unsafe fn from_ptr(ptr: *mut RawInfoBar) -> Self {
+        assert!(!ptr.is_null());
+        InfoBar {
+            handle: WindowHandle::new(ptr as *mut ffi::wxd_Window_t),
+        }
+    }
+
+    pub fn window_handle(&self) -> WindowHandle {
+        self.handle
+    }
+}
+
+impl WxWidget for InfoBar {
+    fn handle_ptr(&self) -> *mut ffi::wxd_Window_t {
+        self.handle.get_ptr().unwrap_or(std::ptr::null_mut())
+    }
+
+    fn is_valid(&self) -> bool {
+        self.handle.is_valid()
+    }
+}
+
+impl WxEvtHandler for InfoBar {
+    unsafe fn get_event_handler_ptr(&self) -> *mut ffi::wxd_EvtHandler_t {
+        self.handle.get_ptr().unwrap_or(std::ptr::null_mut()) as *mut ffi::wxd_EvtHandler_t
+    }
+}
+
+impl crate::event::WindowEvents for InfoBar {}
+
+pub struct InfoBarBuilder<'a> {
+    parent: &'a dyn WxWidget,
+    id: Id,
+}
+
+impl<'a> InfoBarBuilder<'a> {
+    pub fn new(parent: &'a dyn WxWidget) -> Self {
+        Self {
+            parent,
+            id: crate::id::ID_ANY as Id,
+        }
+    }
+
+    pub fn with_id(mut self, id: Id) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn build(self) -> InfoBar {
+        let parent_ptr = self.parent.handle_ptr();
+        unsafe {
+            let ptr = ffi::wxd_InfoBar_Create(parent_ptr, self.id);
+            assert!(!ptr.is_null(), "wxd_InfoBar_Create returned null");
+            InfoBar::from_ptr(ptr)
+        }
+    }
+}
+
+#[cfg(feature = "xrc")]
+impl crate::xrc::XrcSupport for InfoBar {
+    unsafe fn from_xrc_ptr(ptr: *mut ffi::wxd_Window_t) -> Self {
+        InfoBar {
+            handle: WindowHandle::new(ptr),
+        }
+    }
+}
+
+impl crate::window::FromWindowWithClassName for InfoBar {
+    fn class_name() -> &'static str {
+        "wxInfoBar"
+    }
+
+    unsafe fn from_ptr(ptr: *mut ffi::wxd_Window_t) -> Self {
+        InfoBar {
+            handle: WindowHandle::new(ptr),
+        }
+    }
+}

--- a/rust/wxdragon/src/widgets/mod.rs
+++ b/rust/wxdragon/src/widgets/mod.rs
@@ -34,6 +34,7 @@ pub mod gauge;
 pub mod generic_static_bitmap;
 pub mod grid;
 pub mod hyperlink_ctrl;
+pub mod info_bar;
 pub mod item_data;
 pub mod list_ctrl;
 pub mod listbox;
@@ -48,6 +49,7 @@ pub mod property_grid;
 pub mod radio_button;
 pub mod radiobox;
 pub mod rearrangelist;
+pub mod rich_tool_tip;
 #[cfg(feature = "richtext")]
 pub mod richtextctrl;
 pub mod scrollbar;
@@ -134,6 +136,7 @@ pub use grid::{
 // GenericStaticBitmap is mainly for internal use by the platform-aware XRC handler
 pub use generic_static_bitmap::{GenericStaticBitmap, GenericStaticBitmapBuilder};
 pub use hyperlink_ctrl::{HyperlinkCtrl, HyperlinkCtrlBuilder};
+pub use info_bar::*;
 pub use list_ctrl::{ListCtrl, ListCtrlBuilder};
 pub use listbox::{ListBox, ListBoxBuilder};
 pub use mdi_child_frame::{MDIChildFrame, MDIChildFrameBuilder};
@@ -149,6 +152,7 @@ pub use property_grid::{
 pub use radio_button::{RadioButton, RadioButtonBuilder, RadioButtonStyle};
 pub use radiobox::RadioBox;
 pub use rearrangelist::{RearrangeList, RearrangeListEvent, RearrangeListEventData, RearrangeListStyle};
+pub use rich_tool_tip::*;
 #[cfg(feature = "richtext")]
 pub use richtextctrl::{
     RichTextCtrl, RichTextCtrlBuilder, RichTextCtrlEvent, RichTextCtrlEventData, RichTextCtrlStyle, RichTextFileType,

--- a/rust/wxdragon/src/widgets/notification_message.rs
+++ b/rust/wxdragon/src/widgets/notification_message.rs
@@ -1,17 +1,14 @@
-//! Safe wrapper for wxNotificationMessage.
-
+use crate::bitmap_bundle::BitmapBundle;
 use crate::event::{Event, EventType};
+use crate::widgets::taskbar_icon::TaskBarIcon;
 use crate::window::WxWidget;
 use std::ffi::{CString, NulError};
 use std::os::raw::c_int;
 use wxdragon_sys as ffi;
 
-/// Error type for notification message operations.
 #[derive(Debug)]
 pub enum Error {
-    /// A nul byte was found in a string argument.
     NulError(NulError),
-    /// Failed to create the notification message via FFI.
     FfiCreation(String),
 }
 
@@ -21,15 +18,11 @@ impl From<NulError> for Error {
     }
 }
 
-/// Result type alias for notification message operations.
 pub type WxResult<T> = Result<T, Error>;
 
-// wxNotificationMessage specific constants that might be useful
-// These values are from wxWidgets documentation for wxNotificationMessage::Show
-pub const TIMEOUT_AUTO: i32 = -1; // Automatically determine the timeout
-pub const TIMEOUT_NEVER: i32 = 0; // Never hide the notification automatically (manual Close() needed)
+pub const TIMEOUT_AUTO: i32 = -1;
+pub const TIMEOUT_NEVER: i32 = 0;
 
-// Define NotificationStyle using widget_style_enum macro
 widget_style_enum!(
     name: NotificationStyle,
     doc: "Style flags for NotificationMessage.",
@@ -43,40 +36,29 @@ widget_style_enum!(
     default_variant: None
 );
 
-/// Events emitted by NotificationMessage
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationMessageEvent {
-    /// Emitted when the notification is clicked
     Click,
-    /// Emitted when the notification is dismissed
     Dismissed,
-    /// Emitted when an action button is clicked
     Action,
 }
 
-/// Event data for NotificationMessageEvent events
 #[derive(Debug)]
 pub struct NotificationMessageEventData {
     event: Event,
 }
 
 impl NotificationMessageEventData {
-    /// Create a new NotificationMessageEventData from a generic Event
     pub fn new(event: Event) -> Self {
         Self { event }
     }
 
-    /// Get the ID of the notification or the action button that was clicked
     pub fn get_id(&self) -> i32 {
         self.event.get_id()
     }
 }
 
-/// Represents a `wxNotificationMessage`.
-///
-/// This struct manages a pointer to the underlying C++ `wxNotificationMessage` object.
-/// It is responsible for calling `wxd_NotificationMessage_Destroy` when it goes out of scope.
-#[derive(Debug)] // wxNotificationMessage is not Cloneable as it has direct destructor
+#[derive(Debug)]
 pub struct NotificationMessage {
     ptr: *mut ffi::wxd_NotificationMessage_t,
 }
@@ -85,32 +67,40 @@ unsafe impl Send for NotificationMessage {}
 unsafe impl Sync for NotificationMessage {}
 
 impl NotificationMessage {
-    /// Creates a new `NotificationMessageBuilder`.
     pub fn builder() -> NotificationMessageBuilder {
         NotificationMessageBuilder::new()
     }
 
-    /// Shows the notification to the user.
-    ///
-    /// # Arguments
-    /// * `timeout` - How long the notification is shown, in seconds.
-    ///   Use `TIMEOUT_AUTO` to let the system decide, or `TIMEOUT_NEVER` if it shouldn't time out.
-    ///   A positive value specifies the timeout in seconds.
-    ///
-    /// Returns `true` if it was possible to show the notification, `false` if an error occurred.
+    pub fn msw_use_toasts(shortcut_path: &str, app_id: &str) -> bool {
+        let c_path = CString::new(shortcut_path).unwrap_or_default();
+        let c_id = CString::new(app_id).unwrap_or_default();
+        unsafe { ffi::wxd_NotificationMessage_MSWUseToasts(c_path.as_ptr(), c_id.as_ptr()) }
+    }
+
+    pub fn use_taskbar_icon(&self, icon: &TaskBarIcon) {
+        if !self.ptr.is_null() {
+            unsafe {
+                ffi::wxd_NotificationMessage_UseTaskBarIcon(self.ptr, icon.as_ptr());
+            }
+        }
+    }
+
+    pub fn set_icon_bundle(&self, icon: &BitmapBundle) {
+        if !self.ptr.is_null() {
+            unsafe {
+                ffi::wxd_NotificationMessage_SetIcon(self.ptr, icon.as_ptr());
+            }
+        }
+    }
+
     pub fn show(&self, timeout: i32) -> bool {
         unsafe { ffi::wxd_NotificationMessage_Show(self.ptr, timeout as c_int) }
     }
 
-    /// Hides the notification.
-    ///
-    /// Returns `true` if the notification was hidden or `false` if it couldn't be (e.g. it was already hidden).
     pub fn close(&self) -> bool {
         unsafe { ffi::wxd_NotificationMessage_Close(self.ptr) }
     }
 
-    /// Sets the main text of the notification.
-    /// Returns `true` on success.
     pub fn set_title(&self, title: &str) -> WxResult<()> {
         let c_title = CString::new(title)?;
         unsafe {
@@ -119,8 +109,6 @@ impl NotificationMessage {
         Ok(())
     }
 
-    /// Sets the secondary, more detailed, text of the notification.
-    /// Returns `true` on success.
     pub fn set_message(&self, message: &str) -> WxResult<()> {
         let c_message = CString::new(message)?;
         unsafe {
@@ -129,9 +117,6 @@ impl NotificationMessage {
         Ok(())
     }
 
-    /// Sets the style for the notification message.
-    /// These flags typically control the icon shown.
-    /// Returns `true` on success.
     pub fn set_style(&self, style: NotificationStyle) -> WxResult<()> {
         unsafe {
             ffi::wxd_NotificationMessage_SetFlags(self.ptr, style.bits() as c_int);
@@ -139,8 +124,6 @@ impl NotificationMessage {
         Ok(())
     }
 
-    /// Sets the parent window for this notification.
-    /// Returns `true` on success.
     pub fn set_parent<W: WxWidget>(&self, parent: Option<&W>) -> WxResult<()> {
         let parent_ptr = parent.map_or(std::ptr::null_mut(), |p| p.handle_ptr());
         unsafe {
@@ -149,29 +132,15 @@ impl NotificationMessage {
         Ok(())
     }
 
-    /// Adds an action button to the notification.
-    ///
-    /// This method should be called after the `NotificationMessage` has been created
-    /// but before `show()` is called for the actions to appear.
-    /// The `action_id` will be returned by `event.get_id()` if the corresponding
-    /// action button is clicked and an `EventType::NotificationMessageAction` is caught.
-    ///
-    /// # Arguments
-    /// * `action_id` - An integer ID for this action. Must be > 0.
-    /// * `label` - The text to display on the action button.
-    ///
-    /// Returns `true` if the action was added successfully, `false` otherwise (e.g., too many actions).
     pub fn add_action(&self, action_id: i32, label: &str) -> WxResult<bool> {
         if self.ptr.is_null() {
             return Err(Error::FfiCreation("NotificationMessage pointer is null".to_string()));
         }
         if action_id <= 0 {
-            // wxWidgets requires action IDs to be > 0
-            // Consider returning a specific error type here
             log::warn!("NotificationMessage action_id must be > 0.");
             return Ok(false);
         }
-        let c_label = CString::new(label)?; // This can return NulError, which converts to Error::NulError
+        let c_label = CString::new(label)?;
         let result = unsafe { ffi::wxd_NotificationMessage_AddAction(self.ptr, action_id, c_label.as_ptr()) };
         Ok(result)
     }
@@ -183,14 +152,12 @@ impl NotificationMessage {
         }
     }
 
-    /// Gets the raw pointer to the notification message
     #[allow(dead_code)]
     pub(crate) fn get_ptr(&self) -> *mut ffi::wxd_NotificationMessage_t {
         self.ptr
     }
 }
 
-// Implement event handlers for NotificationMessage
 crate::implement_widget_local_event_handlers!(
     NotificationMessage,
     NotificationMessageEvent,
@@ -200,15 +167,11 @@ crate::implement_widget_local_event_handlers!(
     Action => action, EventType::NOTIFICATION_MESSAGE_ACTION
 );
 
-// Special implementation of WxEvtHandler for NotificationMessage
 impl crate::event::WxEvtHandler for NotificationMessage {
     unsafe fn get_event_handler_ptr(&self) -> *mut ffi::wxd_EvtHandler_t {
         self.ptr as *mut ffi::wxd_EvtHandler_t
     }
 }
-
-// Since NotificationMessage is not a true window, we don't implement WindowEvents
-// However, we can still bind specific events defined above
 
 impl Drop for NotificationMessage {
     fn drop(&mut self) {
@@ -216,59 +179,71 @@ impl Drop for NotificationMessage {
     }
 }
 
-/// Builder for `NotificationMessage` instances.
-#[derive(Default)]
 pub struct NotificationMessageBuilder {
     title: String,
     message: String,
     parent: Option<*mut ffi::wxd_Window_t>,
     style: NotificationStyle,
+    use_generic: bool,
+}
+
+impl Default for NotificationMessageBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NotificationMessageBuilder {
-    /// Creates a new builder with default values.
     pub fn new() -> Self {
         NotificationMessageBuilder {
             title: String::new(),
             message: String::new(),
             parent: None,
             style: NotificationStyle::None,
+            // Default to the generic backend on Windows: the native backend has a history of
+            // causing app hangs and leaving persistent taskbar icons. Callers who want the
+            // native (toast-capable) backend on Windows can opt in via `.with_generic(false)`.
+            use_generic: cfg!(target_os = "windows"),
         }
     }
 
-    /// Sets the main title of the notification.
     pub fn with_title(mut self, title: &str) -> Self {
         self.title = title.to_string();
         self
     }
 
-    /// Sets the detailed message of the notification.
     pub fn with_message(mut self, message: &str) -> Self {
         self.message = message.to_string();
         self
     }
 
-    /// Sets the parent window.
     pub fn with_parent<W: WxWidget>(mut self, parent: &W) -> Self {
         self.parent = Some(parent.handle_ptr());
         self
     }
 
-    /// Sets the style (e.g., for icons like `NotificationStyle::Information`).
     pub fn with_style(mut self, style: NotificationStyle) -> Self {
         self.style = style;
         self
     }
 
-    /// Builds the `NotificationMessage`.
-    ///
-    /// Returns `Some(NotificationMessage)` on success, or `None` if creation failed.
+    pub fn with_generic(mut self, generic: bool) -> Self {
+        self.use_generic = generic;
+        self
+    }
+
     pub fn build(self) -> WxResult<NotificationMessage> {
         let c_title = CString::new(self.title)?;
         let msg = CString::new(self.message)?;
         let prt = self.parent.unwrap_or(std::ptr::null_mut());
 
-        let ptr = unsafe { ffi::wxd_NotificationMessage_Create(c_title.as_ptr(), msg.as_ptr(), prt, self.style.bits() as c_int) };
+        let ptr = unsafe {
+            if self.use_generic {
+                ffi::wxd_NotificationMessage_CreateGeneric(c_title.as_ptr(), msg.as_ptr(), prt, self.style.bits() as c_int)
+            } else {
+                ffi::wxd_NotificationMessage_Create(c_title.as_ptr(), msg.as_ptr(), prt, self.style.bits() as c_int)
+            }
+        };
 
         if ptr.is_null() {
             return Err(Error::FfiCreation("Failed to create notification message".to_string()));

--- a/rust/wxdragon/src/widgets/rich_tool_tip.rs
+++ b/rust/wxdragon/src/widgets/rich_tool_tip.rs
@@ -1,0 +1,191 @@
+use crate::bitmap_bundle::BitmapBundle;
+use crate::color::Colour;
+use crate::font::Font;
+use crate::geometry::Rect;
+use crate::window::WxWidget;
+use std::ffi::CString;
+use wxdragon_sys as ffi;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(i32)]
+pub enum TipKind {
+    None = 0,
+    TopLeft = 1,
+    Top = 2,
+    TopRight = 3,
+    BottomLeft = 4,
+    Bottom = 5,
+    BottomRight = 6,
+    #[default]
+    Auto = 7,
+}
+
+pub struct RichToolTip {
+    ptr: *mut ffi::wxd_RichToolTip_t,
+}
+
+unsafe impl Send for RichToolTip {}
+unsafe impl Sync for RichToolTip {}
+
+impl RichToolTip {
+    pub fn new(title: &str, message: &str) -> Self {
+        let c_title = CString::new(title).unwrap_or_default();
+        let c_msg = CString::new(message).unwrap_or_default();
+        let ptr = unsafe { ffi::wxd_RichToolTip_Create(c_title.as_ptr(), c_msg.as_ptr()) };
+        assert!(!ptr.is_null(), "wxd_RichToolTip_Create returned null");
+        RichToolTip { ptr }
+    }
+
+    pub fn builder(title: &str, message: &str) -> RichToolTipBuilder {
+        RichToolTipBuilder::new(title, message)
+    }
+
+    pub fn set_background_colour(&self, col: &Colour, col_end: Option<&Colour>) {
+        let raw_col = col.to_raw();
+        let raw_col_end = col_end.map(|c| c.to_raw());
+        let end_ptr = raw_col_end
+            .as_ref()
+            .map_or(std::ptr::null(), |c| c as *const ffi::wxd_Colour_t);
+        unsafe {
+            ffi::wxd_RichToolTip_SetBackgroundColour(self.ptr, &raw_col, end_ptr);
+        }
+    }
+
+    pub fn set_title_font(&self, font: &Font) {
+        unsafe {
+            ffi::wxd_RichToolTip_SetTitleFont(self.ptr, font.as_ptr());
+        }
+    }
+
+    pub fn set_icon(&self, icon: i32) {
+        unsafe {
+            ffi::wxd_RichToolTip_SetIcon(self.ptr, icon);
+        }
+    }
+
+    pub fn set_custom_icon(&self, icon: &BitmapBundle) {
+        unsafe {
+            ffi::wxd_RichToolTip_SetCustomIcon(self.ptr, icon.as_ptr());
+        }
+    }
+
+    pub fn set_timeout(&self, milliseconds: u32, show_delay_ms: u32) {
+        unsafe {
+            ffi::wxd_RichToolTip_SetTimeout(self.ptr, milliseconds, show_delay_ms);
+        }
+    }
+
+    pub fn set_tip_kind(&self, tip_kind: TipKind) {
+        unsafe {
+            ffi::wxd_RichToolTip_SetTipKind(self.ptr, tip_kind as i32);
+        }
+    }
+
+    pub fn show_for(&self, window: &impl WxWidget) {
+        let win_ptr = window.handle_ptr();
+        unsafe {
+            ffi::wxd_RichToolTip_ShowFor(self.ptr, win_ptr, std::ptr::null());
+        }
+    }
+
+    pub fn show_for_rect(&self, window: &impl WxWidget, rect: &Rect) {
+        let win_ptr = window.handle_ptr();
+        let raw_rect: ffi::wxd_Rect = (*rect).into();
+        unsafe {
+            ffi::wxd_RichToolTip_ShowFor(self.ptr, win_ptr, &raw_rect);
+        }
+    }
+}
+
+impl Drop for RichToolTip {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                ffi::wxd_RichToolTip_Destroy(self.ptr);
+            }
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}
+
+pub struct RichToolTipBuilder {
+    title: String,
+    message: String,
+    bg_col: Option<Colour>,
+    bg_col_end: Option<Colour>,
+    title_font: Option<Font>,
+    icon_flag: Option<i32>,
+    custom_icon: Option<BitmapBundle>,
+    timeout_ms: Option<(u32, u32)>,
+    tip_kind: Option<TipKind>,
+}
+
+impl RichToolTipBuilder {
+    pub fn new(title: &str, message: &str) -> Self {
+        Self {
+            title: title.to_string(),
+            message: message.to_string(),
+            bg_col: None,
+            bg_col_end: None,
+            title_font: None,
+            icon_flag: None,
+            custom_icon: None,
+            timeout_ms: None,
+            tip_kind: None,
+        }
+    }
+
+    pub fn with_background_colour(mut self, col: Colour, col_end: Option<Colour>) -> Self {
+        self.bg_col = Some(col);
+        self.bg_col_end = col_end;
+        self
+    }
+
+    pub fn with_title_font(mut self, font: Font) -> Self {
+        self.title_font = Some(font);
+        self
+    }
+
+    pub fn with_icon(mut self, icon: i32) -> Self {
+        self.icon_flag = Some(icon);
+        self
+    }
+
+    pub fn with_custom_icon(mut self, icon: BitmapBundle) -> Self {
+        self.custom_icon = Some(icon);
+        self
+    }
+
+    pub fn with_timeout(mut self, milliseconds: u32, show_delay_ms: u32) -> Self {
+        self.timeout_ms = Some((milliseconds, show_delay_ms));
+        self
+    }
+
+    pub fn with_tip_kind(mut self, tip_kind: TipKind) -> Self {
+        self.tip_kind = Some(tip_kind);
+        self
+    }
+
+    pub fn build(self) -> RichToolTip {
+        let tip = RichToolTip::new(&self.title, &self.message);
+        if let Some(bg) = &self.bg_col {
+            tip.set_background_colour(bg, self.bg_col_end.as_ref());
+        }
+        if let Some(font) = &self.title_font {
+            tip.set_title_font(font);
+        }
+        if let Some(flag) = self.icon_flag {
+            tip.set_icon(flag);
+        }
+        if let Some(icon) = &self.custom_icon {
+            tip.set_custom_icon(icon);
+        }
+        if let Some((ms, delay)) = self.timeout_ms {
+            tip.set_timeout(ms, delay);
+        }
+        if let Some(kind) = self.tip_kind {
+            tip.set_tip_kind(kind);
+        }
+        tip
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a wrapper for `wxInfoBar` (show/dismiss messages, buttons, show/hide effects).
- Adds a wrapper for `wxRichToolTip` (title/message, background colour, icon, timeout, tip kind).
- Reworks `NotificationMessage` so it can use either the generic or the native backend, via `NotificationMessageBuilder::with_generic()`, and adds `use_taskbar_icon` / `msw_use_toasts` for the native Windows toast backend.

## Motivation

InfoBar and RichToolTip were two commonly used wx widgets that wxDragon didn't expose yet — this adds both, following the same wrapper style as the rest of the crate.

While working on NotificationMessage's new Windows toast support, I also found and fixed a couple of issues with the existing implementation:
- The native backend on Windows has a known history of causing app hangs and leaving persistent taskbar icons, so the generic backend needs to stay the default there; it had regressed to defaulting to native.
- `UseTaskBarIcon` was reinterpret-casting to `wxNotificationMessage*` unconditionally, which is undefined behavior when the notification was actually created with the generic backend (a different, unrelated class). It now uses a `dynamic_cast` and is a safe no-op in that case.
## Test plan

- `cargo check --workspace --features "aui,webview,stc,richtext"` succeeds locally (Windows/MSVC).
- `cargo clippy --workspace --features "aui,webview,stc,richtext" --all-targets` is clean (no new warnings).
- `cargo fmt --all --check` passes.