### PR TITLE
Fix UB: double-destroy race in Clone-able dialog wrappers

### DIFF
--- a/rust/wxdragon/src/dialogs/file_dialog.rs
+++ b/rust/wxdragon/src/dialogs/file_dialog.rs
@@ -252,8 +252,12 @@ impl WxWidget for FileDialog {
 // Implement Drop
 impl Drop for FileDialog {
     fn drop(&mut self) {
-        // The composed Dialog's Drop will be called automatically,
-        // which calls wxd_Window_Destroy on the pointer.
+        // Dialog itself has no Drop impl (this comment previously claimed
+        // otherwise), so this no-op silently leaked the underlying window.
+        // destroy_once() is idempotent across Clones of this dialog - see its
+        // doc comment for why calling wxd_Window_Destroy directly would risk
+        // a double-free.
+        self.dialog_base.destroy_once();
     }
 }
 

--- a/rust/wxdragon/src/dialogs/message_dialog.rs
+++ b/rust/wxdragon/src/dialogs/message_dialog.rs
@@ -93,19 +93,10 @@ impl WxWidget for MessageDialog {
 
 impl Drop for MessageDialog {
     fn drop(&mut self) {
-        if !self.handle_ptr().is_null() {
-            // Ensure Rust knows this pointer is managed by Rust for this instance.
-            // If this instance is a simple wrapper not owning the underlying object,
-            // (e.g. from a GetParent call), then this Drop might be too aggressive.
-            // For dialogs created via builder, they are owned.
-            unsafe {
-                // Check if it's already being destroyed by wxWidgets or a parent
-                // For dialogs shown modally, they are often auto-destroyed or parented such that
-                // wxWidgets handles their deletion. However, explicit Destroy is safer if we created it.
-                // The current C API relies on wxd_Window_Destroy.
-                ffi::wxd_Window_Destroy(self.handle_ptr());
-            }
-        }
+        // destroy_once() is idempotent across Clones of this dialog - see its
+        // doc comment for why calling wxd_Window_Destroy directly here would
+        // risk a double-free.
+        self.dialog_base.destroy_once();
     }
 }
 

--- a/rust/wxdragon/src/dialogs/mod.rs
+++ b/rust/wxdragon/src/dialogs/mod.rs
@@ -93,6 +93,15 @@ impl Dialog {
         self.handle
     }
 
+    /// Idempotently destroys the underlying dialog exactly once, even if
+    /// called from multiple `Clone`s of the same dialog. See
+    /// [`WindowHandle::destroy`] for why this matters: `wxd_Window_Destroy`
+    /// defers actual deletion, so naively calling it from every clone's
+    /// `Drop` can queue a double-delete before the event loop catches up.
+    pub(crate) fn destroy_once(&self) -> bool {
+        self.handle.destroy()
+    }
+
     /// Sets the icon for the dialog.
     /// No-op if the dialog has been destroyed.
     pub fn set_icon(&self, bitmap: &Bitmap) {

--- a/rust/wxdragon/src/dialogs/multi_choice_dialog.rs
+++ b/rust/wxdragon/src/dialogs/multi_choice_dialog.rs
@@ -106,7 +106,12 @@ impl WxWidget for MultiChoiceDialog {
 // Implement Drop
 impl Drop for MultiChoiceDialog {
     fn drop(&mut self) {
-        // The Dialog's drop will be called automatically
+        // Dialog itself has no Drop impl (this comment previously claimed
+        // otherwise), so this no-op silently leaked the underlying window.
+        // destroy_once() is idempotent across Clones of this dialog - see its
+        // doc comment for why calling wxd_Window_Destroy directly would risk
+        // a double-free.
+        self.dialog_base.destroy_once();
     }
 }
 

--- a/rust/wxdragon/src/dialogs/progress_dialog.rs
+++ b/rust/wxdragon/src/dialogs/progress_dialog.rs
@@ -233,9 +233,9 @@ impl WxWidget for ProgressDialog {
 // Add a Drop implementation for ProgressDialog for proper cleanup
 impl Drop for ProgressDialog {
     fn drop(&mut self) {
-        unsafe {
-            // Use destroy from the Window trait to clean up resources
-            ffi::wxd_Window_Destroy(self.handle_ptr());
-        }
+        // destroy_once() is idempotent across Clones of this dialog and
+        // handles the null case - see its doc comment for why calling
+        // wxd_Window_Destroy directly here would risk a double-free.
+        self.dialog_base.destroy_once();
     }
 }

--- a/rust/wxdragon/src/dialogs/single_choice_dialog.rs
+++ b/rust/wxdragon/src/dialogs/single_choice_dialog.rs
@@ -103,7 +103,12 @@ impl WxWidget for SingleChoiceDialog {
 // Implement Drop
 impl Drop for SingleChoiceDialog {
     fn drop(&mut self) {
-        // The Dialog's drop will be called automatically
+        // Dialog itself has no Drop impl (this comment previously claimed
+        // otherwise), so this no-op silently leaked the underlying window.
+        // destroy_once() is idempotent across Clones of this dialog - see its
+        // doc comment for why calling wxd_Window_Destroy directly would risk
+        // a double-free.
+        self.dialog_base.destroy_once();
     }
 }
 

--- a/rust/wxdragon/src/dialogs/text_entry_dialog.rs
+++ b/rust/wxdragon/src/dialogs/text_entry_dialog.rs
@@ -89,8 +89,12 @@ impl WxWidget for TextEntryDialog {
 // Implement Drop
 impl Drop for TextEntryDialog {
     fn drop(&mut self) {
-        // The composed Dialog's Drop will be called automatically,
-        // which calls wxd_Window_Destroy on the pointer.
+        // Dialog itself has no Drop impl (this comment previously claimed
+        // otherwise), so this no-op silently leaked the underlying window.
+        // destroy_once() is idempotent across Clones of this dialog - see its
+        // doc comment for why calling wxd_Window_Destroy directly would risk
+        // a double-free.
+        self.dialog_base.destroy_once();
     }
 }
 

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -101,6 +101,30 @@ impl WindowHandle {
         self.get_ptr().is_some()
     }
 
+    /// Idempotently destroys the underlying window exactly once.
+    ///
+    /// `wxd_Window_Destroy` defers the actual C++ deletion (via
+    /// `wxPendingDelete`/`CallAfter`), processed later at idle time - the
+    /// `wxEVT_DESTROY`-driven invalidation in [`Self::new`] does NOT fire
+    /// synchronously. So if this were called twice before the event loop
+    /// reaches idle (e.g. from two `Clone`s of the same widget being dropped
+    /// back-to-back), the underlying pointer would be queued for deletion
+    /// twice - a double-free once wxWidgets processes its pending-delete list.
+    ///
+    /// This method closes that race by invalidating the registry entry
+    /// immediately, before issuing the deferred destroy, so any other handle
+    /// sharing this id sees it as already-destroyed right away rather than
+    /// waiting for the async wx event. Returns `false` (no-op) if the handle
+    /// was already invalidated by a previous call.
+    pub(crate) fn destroy(&self) -> bool {
+        let Some(ptr) = self.get_ptr() else {
+            return false;
+        };
+        Self::invalidate(self.0);
+        unsafe { ffi::wxd_Window_Destroy(ptr) };
+        true
+    }
+
     /// Internal: Remove handle from registry (called when window is destroyed)
     fn invalidate(handle_id: u64) {
         WINDOW_REGISTRY.with(|r| {


### PR DESCRIPTION
## Problem

`MessageDialog` and `ProgressDialog` are `#[derive(Clone)]` and each had its own `Drop` calling `ffi::wxd_Window_Destroy` directly, independent of other clones.

`wxd_Window_Destroy` defers actual deletion via `wxPendingDelete`/`CallAfter`, processed later at idle time. The `WindowHandle` registry that's supposed to make stale pointers safe is **not** invalidated synchronously when `Destroy()` is called — it only updates when the deferred `wxEVT_DESTROY` actually fires. If two clones of the same dialog are dropped before the event loop reaches idle, `wxd_Window_Destroy` gets queued twice against the same live pointer — a real double-free once wxWidgets processes its pending-delete list.

While implementing the fix I found a related bug in the other four Clone-able dialogs: `FileDialog`, `MultiChoiceDialog`, `SingleChoiceDialog`, and `TextEntryDialog` all had **empty** `Drop` bodies with a comment claiming "the composed Dialog's Drop will be called automatically" — but `Dialog` itself has no `Drop` impl at all, so these were silently leaking the underlying window on every drop instead of double-freeing.

## Fix

- Added `WindowHandle::destroy(&self) -> bool` in `window.rs`: looks up the pointer, and if found, invalidates the registry entry **immediately** (before issuing the deferred `wxd_Window_Destroy`), so a second call from another clone sees it as already-destroyed right away instead of waiting on the async wx event. Returns `false` (no-op) if already invalidated.
- Added `Dialog::destroy_once()` as the safe entry point other dialog types should call.
- Routed all six dialogs' `Drop` impls through it, fixing both the double-destroy race (`MessageDialog`, `ProgressDialog`) and the leak (`FileDialog`, `MultiChoiceDialog`, `SingleChoiceDialog`, `TextEntryDialog`) with the same mechanism.

`DirDialog` (not `Clone`, doesn't compose `Dialog`) and `AboutDialogInfo` (a different underlying type, destroyed via `wxd_AboutDialogInfo_Destroy`) were left untouched — neither has this issue.

## Test plan

- [x] `cargo check -p wxdragon` and `cargo test -p wxdragon --no-run` both pass
- [ ] CI green
- [ ] Manual smoke test: clone one of these dialogs, drop both the clone and the original back-to-back, confirm no crash