### PR TITLE
Fix UB: remove unjustified unsafe impl Send/Sync (BREAKING)

### DIFF
--- a/examples/rust/gallery/src/tabs/dialog_tab.rs
+++ b/examples/rust/gallery/src/tabs/dialog_tab.rs
@@ -1,10 +1,7 @@
 use wxdragon::prelude::*;
 
 use std::time::Duration;
-use std::{
-    sync::{Arc, Mutex},
-    thread,
-};
+use std::{cell::RefCell, rc::Rc, thread};
 
 #[allow(dead_code)]
 pub struct DialogTabControls {
@@ -48,7 +45,7 @@ pub struct DialogTabControls {
     // StdDialogButtonSizer
     pub show_std_btn_sizer_btn: Button,
     // Keep NotificationMessage alive while showing
-    pub notification_message: Arc<Mutex<Option<NotificationMessage>>>,
+    pub notification_message: Rc<RefCell<Option<NotificationMessage>>>,
 }
 
 pub fn create_dialog_tab(notebook: &Notebook, _frame: &Frame) -> DialogTabControls {
@@ -340,7 +337,7 @@ pub fn create_dialog_tab(notebook: &Notebook, _frame: &Frame) -> DialogTabContro
         dlg_dir_button,
         show_about_dialog_btn,
         show_std_btn_sizer_btn,
-        notification_message: Arc::new(Mutex::new(None)),
+        notification_message: Rc::new(RefCell::new(None)),
     }
 }
 
@@ -541,7 +538,7 @@ impl DialogTabControls {
                     notification.show(wxdragon::widgets::notification_message::TIMEOUT_AUTO);
                     notification_status_label.set_label("Notification shown.");
                     println!("NotificationMessage: Shown.");
-                    notif_store.lock().unwrap().replace(notification);
+                    notif_store.borrow_mut().replace(notification);
                 }
                 Err(e) => {
                     notification_status_label.set_label(&format!("Notify Err: {e:?}"));
@@ -709,7 +706,7 @@ impl DialogTabControls {
 
         let notif_store_on_destroy = self.notification_message.clone();
         frame.on_destroy(move |_| {
-            let _ = notif_store_on_destroy.lock().unwrap().take();
+            let _ = notif_store_on_destroy.borrow_mut().take();
         });
     }
 }

--- a/rust/wxdragon/src/app.rs
+++ b/rust/wxdragon/src/app.rs
@@ -285,9 +285,6 @@ fn get_app_string(
     )
 }
 
-unsafe impl Send for App {}
-unsafe impl Sync for App {}
-
 /// Sets the application's top window.
 ///
 /// This is necessary for the main event loop to run correctly.

--- a/rust/wxdragon/src/appearance.rs
+++ b/rust/wxdragon/src/appearance.rs
@@ -162,10 +162,6 @@ impl Drop for SystemAppearance {
     }
 }
 
-// Make SystemAppearance thread-safe for use across threads
-unsafe impl Send for SystemAppearance {}
-unsafe impl Sync for SystemAppearance {}
-
 /// Gets the current system appearance information.
 ///
 /// This function returns information about the current system appearance,

--- a/rust/wxdragon/src/cursor.rs
+++ b/rust/wxdragon/src/cursor.rs
@@ -312,10 +312,6 @@ impl Drop for Cursor {
     }
 }
 
-// Make Cursor Send and Sync for multi-threading support
-unsafe impl Send for Cursor {}
-unsafe impl Sync for Cursor {}
-
 // Global cursor functions
 
 /// Sets the global cursor for the application.

--- a/rust/wxdragon/src/font.rs
+++ b/rust/wxdragon/src/font.rs
@@ -68,8 +68,6 @@ pub struct Font {
     owned: bool, // Track if this instance owns the pointer
 }
 
-unsafe impl Send for Font {}
-
 impl Font {
     /// Creates a new default font.
     pub fn new() -> Self {

--- a/rust/wxdragon/src/sound.rs
+++ b/rust/wxdragon/src/sound.rs
@@ -77,4 +77,3 @@ impl Drop for Sound {
     }
 }
 
-unsafe impl Send for Sound {}

--- a/rust/wxdragon/src/sound.rs
+++ b/rust/wxdragon/src/sound.rs
@@ -76,4 +76,3 @@ impl Drop for Sound {
         }
     }
 }
-

--- a/rust/wxdragon/src/widgets/notification_message.rs
+++ b/rust/wxdragon/src/widgets/notification_message.rs
@@ -63,9 +63,6 @@ pub struct NotificationMessage {
     ptr: *mut ffi::wxd_NotificationMessage_t,
 }
 
-unsafe impl Send for NotificationMessage {}
-unsafe impl Sync for NotificationMessage {}
-
 impl NotificationMessage {
     pub fn builder() -> NotificationMessageBuilder {
         NotificationMessageBuilder::new()

--- a/rust/wxdragon/src/widgets/rich_tool_tip.rs
+++ b/rust/wxdragon/src/widgets/rich_tool_tip.rs
@@ -24,9 +24,6 @@ pub struct RichToolTip {
     ptr: *mut ffi::wxd_RichToolTip_t,
 }
 
-unsafe impl Send for RichToolTip {}
-unsafe impl Sync for RichToolTip {}
-
 impl RichToolTip {
     pub fn new(title: &str, message: &str) -> Self {
         let c_title = CString::new(title).unwrap_or_default();


### PR DESCRIPTION
## ⚠️ Breaking change

This removes API surface. See below for what may need to change downstream.

## Problem

`App`, `Cursor`, `Font`, `SystemAppearance`, `Sound`, `NotificationMessage`, and `RichToolTip` (the last two not caught by the original audit pass, found while implementing this fix) each wrap a bare `*mut ffi::wxd_*_t` with `unsafe impl Send`/`Sync` and no synchronization whatsoever. wxWidgets objects are not thread-safe; this permitted genuine data races by calling into non-thread-safe wx/GTK/Win32 internals from any thread.

`app.rs` already has the *correct* sanctioned mechanism for cross-thread UI work — `MAIN_THREAD_QUEUE`, a `Mutex`-guarded queue drained on the main thread by `process_main_thread_queue`, exposed via `call_after()` — making the blanket `Send`/`Sync` on `App` doubly unnecessary as well as unsafe.

## Fix

Removed all seven `unsafe impl Send`/`Sync` blocks.

Left `rust/wxdragon/src/macros.rs`'s `send_sync` arm of `impl_refcounted_object!` alone — it's an explicit, documented **opt-in** for types that are genuinely thread-safe (atomic `AddRef`/`Release` refcounting), not a blanket unsound impl, and currently has zero call sites in this codebase.

## Migration for downstream consumers

If your code currently moves one of these types to another thread, or stores it inside another `Send` struct, it will no longer compile. Use `wxdragon::call_after()` instead: box the work as a closure and post it to the main thread rather than moving the wx object itself.

## Test plan

- [x] `cargo check -p wxdragon` passes
- [x] `cargo check --workspace` passes (all examples, including `tokio_async_demo` — the one most likely to exercise cross-thread UI patterns — build clean), confirming nothing in this repo relied on the unsound behavior
- [ ] CI green