### PR TITLE
Fix memory leak: Accessible never freed its boxed implementation

### DIFF
--- a/rust/wxdragon-sys/cpp/include/core/wxd_accessible.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_accessible.h
@@ -174,6 +174,10 @@ typedef struct {
     wxd_AccStatus (*GetLocation)(void* userData, int childId, wxd_Rect* rect);
     wxd_AccStatus (*HitTest)(void* userData, wxd_Point pt, int* childId, wxd_Accessible_t** childObject);
     wxd_AccStatus (*Navigate)(void* userData, wxd_NavDir navDir, int fromId, int* toId, wxd_Accessible_t** toObject);
+    // Called exactly once, when the underlying wxAccessible is deleted (whether via
+    // wxd_Accessible_Destroy or by wxWidgets itself, e.g. when replacing/destroying the
+    // owning window's accessible object), to free userData. May be NULL.
+    void (*DestroyUserData)(void* userData);
 } wxd_AccessibleCallbacks;
 
 // --- Accessible Functions ---

--- a/rust/wxdragon-sys/cpp/src/core/accessible.cpp
+++ b/rust/wxdragon-sys/cpp/src/core/accessible.cpp
@@ -11,6 +11,12 @@ public:
         : wxAccessible(win), m_callbacks(callbacks), m_userData(userData)
     {}
 
+    ~WxdCustomAccessible() override {
+        if (m_callbacks.DestroyUserData) {
+            m_callbacks.DestroyUserData(m_userData);
+        }
+    }
+
     wxAccStatus GetChildCount(int* childCount) override {
         if (m_callbacks.GetChildCount) {
             return (wxAccStatus)m_callbacks.GetChildCount(m_userData, childCount);

--- a/rust/wxdragon/src/accessible.rs
+++ b/rust/wxdragon/src/accessible.rs
@@ -310,6 +310,7 @@ impl Accessible {
             GetLocation: Some(accessible_get_location::<T>),
             HitTest: Some(accessible_hit_test::<T>),
             Navigate: Some(accessible_navigate::<T>),
+            DestroyUserData: Some(accessible_destroy_user_data::<T>),
         };
 
         let ptr = unsafe { ffi::wxd_Accessible_Create(window.handle_ptr(), callbacks, user_data as *mut c_void) };
@@ -596,6 +597,12 @@ unsafe extern "C" fn accessible_navigate<T: AccessibleImpl>(
         unsafe { *to_object = std::ptr::null_mut() };
     }
     status.to_ffi()
+}
+
+/// Called by the C++ side exactly once, when the underlying `wxAccessible` is
+/// deleted, to reclaim the `Box<T>` leaked by `Accessible::new`.
+unsafe extern "C" fn accessible_destroy_user_data<T: AccessibleImpl>(user_data: *mut c_void) {
+    unsafe { drop(Box::from_raw(user_data as *mut T)) };
 }
 
 fn copy_string_to_c(s: String, out_buf: *mut c_char, max_len: usize) {


### PR DESCRIPTION
## Problem

`Accessible::new` boxes the user's `AccessibleImpl` via `Box::into_raw` and hands the raw pointer to C++ as `userData` (`rust/wxdragon/src/accessible.rs`), but `wxd_AccessibleCallbacks` had no destroy/free slot, and `wxd_Accessible_Destroy` only did `delete reinterpret_cast<wxAccessible*>(self)` — it never called back into Rust to free the boxed implementation. Every `Accessible::new` permanently leaked the boxed `T`.

## Fix

- Added a `DestroyUserData` callback slot to `wxd_AccessibleCallbacks` (`wxd_accessible.h`).
- Called it from `WxdCustomAccessible`'s destructor rather than only from `wxd_Accessible_Destroy` — this way it fires on *every* deletion path, including ones outside the explicit C API (e.g. wxWidgets itself deleting the accessible when replacing it via `SetAccessible`, or when the owning window is destroyed).
- Added a matching `Box::from_raw` trampoline on the Rust side (`accessible_destroy_user_data<T>`), mirroring the existing closure-cleanup pattern already used for event callbacks elsewhere in the crate.

## Test plan

- [x] `cargo build -p wxdragon-sys`, `cargo check -p wxdragon` pass
- [x] `cargo fmt --check` and `cargo clippy --features "aui,xrc,richtext,stc,webview" -- -D warnings` both clean across the whole workspace
- [ ] CI green