### PR TITLE
Remove dead placeholder code and stale misleading comment

### DIFF
--- a/rust/wxdragon-sys/cpp/src/hyperlink_ctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/hyperlink_ctrl.cpp
@@ -7,29 +7,6 @@
 #include <wx/gdicmn.h> // For wxPoint, wxSize
 #include <wx/colour.h> // For wxColour
 
-// Keep track of allocated C-strings for GetURL so they can be freed later by Rust if needed,
-// or adopt a strategy where Rust always copies the string.
-// For now, we'll return a pointer to wxString's internal buffer. This is generally unsafe
-// if the wxString is temporary or modified. A safer approach is for Rust to provide a buffer.
-// However, GetURL is typically followed by an immediate copy in Rust.
-// Let's assume wxString returned by GetURL() lives as long as the control.
-// A common pattern for C APIs is to return const char* that the caller must copy.
-// wxString::ToUTF8() returns a temporary wxCharBuffer. We need to manage its lifetime.
-// A simple way for now is to have static buffers, but this is not thread-safe or re-entrant.
-// A better C API would involve the caller providing the buffer.
-// Given the existing patterns (e.g. wxd_TextCtrl_GetValue), they expect the Rust side to manage this.
-// For GetURL, wxHyperlinkCtrl::GetURL() returns a const wxString&.
-// wxString::mb_str() or wxString::ToUTF8() can be used. ToUTF8() is preferred.
-// The result of ToUTF8() is a wxCharBuffer, which owns the memory.
-// To return a `const char*` that's valid after the function returns, we'd typically
-// need to `strdup` it or use a static buffer (bad).
-// For wxWidgets, `wxString::utf8_str()` returns `wxScopedCharBuffer` which has `data()` method.
-// The `wxScopedCharBuffer` itself must not go out of scope.
-// Let's follow the pattern potentially used in `wxd_Frame_GetTitle`
-// which likely rely on wxString's internal buffer or a temporary buffer which Rust copies immediately.
-// For now, we'll return `link->GetURL().ToUTF8().data()`. This is risky if not copied immediately.
-// A robust solution would be for Rust to allocate and pass a buffer.
-
 WXD_EXPORTED wxd_HyperlinkCtrl_t*
 wxd_HyperlinkCtrl_Create(wxd_Window_t* parent, int id, const char* label, const char* url, int x,
                          int y, int w, int h, int64_t style)

--- a/rust/wxdragon-sys/src/lib.rs
+++ b/rust/wxdragon-sys/src/lib.rs
@@ -34,33 +34,6 @@ mod logging4c;
 
 // Need to find the actual values for these constants. // REMOVED Comment
 
-// Add necessary imports for the drop function
-use std::cell::RefCell;
-use std::os::raw::c_void;
-
-// Type placeholder for user data until a proper type is defined in the safe wrapper
-type WindowUserData = (); // Replace with actual user data type later if needed
-
-/// Function called by C++ (WxdRustClientData destructor) to drop the Rust `Box<RefCell<T>>`.
-/// # Safety
-/// The caller (C++) must ensure `user_data_ptr` is a valid pointer obtained
-/// from `Box::into_raw(Box::new(RefCell::new(data)))` and that it hasn't been
-/// dropped or invalidated since.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn drop_rust_refcell_box(user_data_ptr: *mut c_void) {
-    if !user_data_ptr.is_null() {
-        // Reconstitute the Box and let it drop, freeing the memory
-        // and dropping the RefCell<WindowUserData>.
-        let _boxed_refcell: Box<RefCell<WindowUserData>> =
-            unsafe { Box::from_raw(user_data_ptr as *mut RefCell<WindowUserData>) };
-        // Drop happens automatically when `_boxed_refcell` goes out of scope here.
-    } else {
-        // Optional: Log a warning or handle null pointer case if necessary
-        // eprintln!("Warning: drop_rust_refcell_box called with null pointer.");
-    }
-}
-
 /// Function to properly free a string that was allocated by Rust using CString::into_raw().
 /// This must be called instead of C's free() for strings allocated by Rust.
 /// # Safety


### PR DESCRIPTION
Two small hygiene fixes found while auditing for UB, neither exploitable today but both worth removing:

## `drop_rust_refcell_box` (wxdragon-sys/src/lib.rs)

An exported `#[no_mangle]` symbol built around a placeholder `type WindowUserData = ()`, with a doc comment claiming it's "called by C++ (`WxdRustClientData` destructor)" — but no such class exists anywhere in the C++ side, and grepping the whole repo turns up zero callers on either side of the FFI boundary. If anything ever did call it against a real (non-unit) `T`, the allocator size/align used at dealloc (`()`) wouldn't match the original allocation — that's UB. Deleted it outright rather than leave a live exported footgun with no purpose.

## Stale comment in `hyperlink_ctrl.cpp`

A ~20-line comment block describes a "risky" approach (returning a dangling pointer into a temporary `wxCharBuffer`) as if it were the implementation, but `wxd_HyperlinkCtrl_GetURL` right below it already uses the safe `copy_wxstring_to_buffer` helper. Deleted the comment so it doesn't mislead a future contributor into reintroducing the unsafe pattern it describes.

## Test plan

- [x] `cargo build -p wxdragon-sys`, `cargo check -p wxdragon` pass
- [x] `cargo fmt --check` and `cargo clippy --features "aui,xrc,richtext,stc,webview" -- -D warnings` both clean
- [ ] CI green