### PR TITLE
Fix UB: cross-allocator mismatch freeing strdup'd strings

### DIFF
--- a/rust/wxdragon-sys/cpp/include/wxd_variant.h
+++ b/rust/wxdragon-sys/cpp/include/wxd_variant.h
@@ -11,6 +11,14 @@ typedef struct wxd_Variant_t wxd_Variant_t;
 extern "C" {
 #endif
 
+// Frees a string that was allocated on the C/C++ side (e.g. via strdup()), such as
+// the ones returned by wxd_Frame_GetTitle, wxd_FilePickerCtrl_GetPath, and the
+// FSWatcher event path/error accessors. Rust must call this instead of
+// CString::from_raw() on such strings - the latter would deallocate C-runtime-
+// allocated memory with Rust's global allocator, which is undefined behavior.
+WXD_EXPORTED void
+wxd_FreeCString(char* str);
+
 // New typed API (preferred)
 WXD_EXPORTED wxd_Variant_t*
 wxd_Variant_CreateEmpty(void);

--- a/rust/wxdragon-sys/cpp/src/wxd_utils.cpp
+++ b/rust/wxdragon-sys/cpp/src/wxd_utils.cpp
@@ -1,8 +1,15 @@
 #include <wx/wx.h>
 #include "wxd_utils.h"
+#include "../include/wxd_variant.h" // For the wxd_FreeCString declaration
 #include <cstring>   // For strncpy, strlen
 #include <algorithm> // For std::min
 #include <cstdlib>   // For strdup
+
+WXD_EXPORTED void
+wxd_FreeCString(char* str)
+{
+    free(str);
+}
 
 namespace wxd_cpp_utils {
 

--- a/rust/wxdragon/src/event/fswatcher_events.rs
+++ b/rust/wxdragon/src/event/fswatcher_events.rs
@@ -1,7 +1,6 @@
 //! Event system for `FileSystemWatcher`.
 
 use crate::event::{Event, EventType};
-use std::ffi::CString;
 use wxdragon_sys as ffi;
 
 /// Events specific to `FileSystemWatcher`.
@@ -118,8 +117,12 @@ fn string_from_owned_c_str(ptr: *mut std::os::raw::c_char) -> String {
     if ptr.is_null() {
         return String::new();
     }
-    // SAFETY: the C side hands us a strdup'd string it no longer owns.
-    unsafe { CString::from_raw(ptr) }.to_string_lossy().into_owned()
+    // The C side hands us a strdup'd string it no longer owns. Read it via a
+    // borrowing CStr and free it with wxd_FreeCString, NOT CString::from_raw,
+    // which would deallocate C-runtime memory with Rust's global allocator.
+    let s = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_string_lossy().into_owned();
+    unsafe { ffi::wxd_FreeCString(ptr) };
+    s
 }
 
 // Use the macro to implement the trait

--- a/rust/wxdragon/src/widgets/file_picker_ctrl.rs
+++ b/rust/wxdragon/src/widgets/file_picker_ctrl.rs
@@ -124,10 +124,14 @@ impl FilePickerCtrl {
         }
         let c_str = unsafe { ffi::wxd_FilePickerCtrl_GetPath(ptr) };
         if c_str.is_null() {
-            String::new()
-        } else {
-            unsafe { CString::from_raw(c_str as *mut _).to_string_lossy().into_owned() }
+            return String::new();
         }
+        // c_str was allocated by the C++ side (strdup) - read it via a borrowing
+        // CStr and free it with wxd_FreeCString, NOT CString::from_raw, which
+        // would deallocate C-runtime memory with Rust's global allocator.
+        let path = unsafe { std::ffi::CStr::from_ptr(c_str) }.to_string_lossy().into_owned();
+        unsafe { ffi::wxd_FreeCString(c_str as *mut _) };
+        path
     }
 
     /// Sets the currently selected path.

--- a/rust/wxdragon/src/widgets/frame.rs
+++ b/rust/wxdragon/src/widgets/frame.rs
@@ -387,12 +387,14 @@ impl Frame {
         if c_title_ptr.is_null() {
             return String::new(); // Should ideally not happen if C returns empty string for null frame
         }
-        // CString::from_raw takes ownership and will free the memory.
-        unsafe {
-            CString::from_raw(c_title_ptr)
-                .into_string()
-                .unwrap_or_else(|_| String::from("Error converting title"))
-        }
+        // c_title_ptr was allocated by the C++ side (strdup) - read it via a
+        // borrowing CStr and free it with wxd_FreeCString, NOT CString::from_raw,
+        // which would deallocate C-runtime memory with Rust's global allocator.
+        let title = unsafe { std::ffi::CStr::from_ptr(c_title_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { ffi::wxd_FreeCString(c_title_ptr) };
+        title
     }
 
     /// Iconizes or restores the frame.


### PR DESCRIPTION
## Problem

`wxd_Frame_GetTitle`, `wxd_FilePickerCtrl_GetPath`, and the three FSWatcher event path/error accessors return a `strdup`'d `char*` (C runtime allocated), but the Rust side reclaimed it with `CString::from_raw`, which deallocates using **Rust's global allocator** on drop. That's a cross-allocator mismatch — undefined behavior, and a real risk of heap corruption, especially on Windows where the C++ shim and Rust binary can link different CRTs. One call site's own comment even said *"the C side hands us a strdup'd string"* while still calling `CString::from_raw` on it.

## Fix

Added `wxd_FreeCString` (implemented in C++, frees via the C runtime's `free()`) and switched all five call sites to read the string through a borrowing `CStr`, then explicitly free it with `wxd_FreeCString` instead of transferring (fake) ownership to a `CString`.

### A wrinkle worth calling out

The natural home for the new declaration would have been `wxd_utils.h`, but `wxdragon.h` only `#include`s that file inside an `#ifdef __cplusplus` guard — which bindgen's C-mode parse never satisfies. So *nothing* declared there, including the pre-existing `wxd_Variant_Free_Rust_String`, is ever visible to bindgen. That one never needed to be (Rust implements it and never calls it through the `ffi::` binding), but `wxd_FreeCString` is the reverse direction (Rust calls into C++) and does need bindgen to see it — so I put the declaration in `wxd_variant.h` instead, which is included unconditionally and already has a working self-contained `extern "C"` guard, matching the pattern the rest of the crate's headers use.

## Test plan

- [x] `cargo build -p wxdragon-sys`, `cargo check -p wxdragon` (default and all-features) pass
- [x] `cargo fmt --check` and `cargo clippy --features "aui,xrc,richtext,stc,webview" -- -D warnings` both clean across the whole workspace
- [x] CI green