### PR TITLE
Harden read_string_with_retry against untrusted retry-call length

### DIFF
--- a/rust/wxdragon/src/widgets/richtextctrl.rs
+++ b/rust/wxdragon/src/widgets/richtextctrl.rs
@@ -213,7 +213,11 @@ impl RichTextCtrl {
                 return String::new();
             }
         }
-        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len as usize) };
+        // Clamp to the buffer's actual size: if the retry call still reports a
+        // length >= buffer.len() (e.g. the underlying value changed between the
+        // two calls), trusting it verbatim would read past the allocation.
+        let safe_len = (len as usize).min(buffer.len());
+        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, safe_len) };
         String::from_utf8_lossy(byte_slice).to_string()
     }
 

--- a/rust/wxdragon/src/widgets/styledtextctrl.rs
+++ b/rust/wxdragon/src/widgets/styledtextctrl.rs
@@ -439,7 +439,11 @@ impl StyledTextCtrl {
                 return String::new();
             }
         }
-        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len as usize) };
+        // Clamp to the buffer's actual size: if the retry call still reports a
+        // length >= buffer.len() (e.g. the underlying value changed between the
+        // two calls), trusting it verbatim would read past the allocation.
+        let safe_len = (len as usize).min(buffer.len());
+        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, safe_len) };
         String::from_utf8_lossy(byte_slice).to_string()
     }
 

--- a/rust/wxdragon/src/widgets/textctrl.rs
+++ b/rust/wxdragon/src/widgets/textctrl.rs
@@ -182,7 +182,11 @@ impl TextCtrl {
                 return String::new();
             }
         }
-        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len as usize) };
+        // Clamp to the buffer's actual size: if the retry call still reports a
+        // length >= buffer.len() (e.g. the underlying value changed between the
+        // two calls), trusting it verbatim would read past the allocation.
+        let safe_len = (len as usize).min(buffer.len());
+        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, safe_len) };
         String::from_utf8_lossy(byte_slice).to_string()
     }
 

--- a/rust/wxdragon/src/widgets/treelistctrl.rs
+++ b/rust/wxdragon/src/widgets/treelistctrl.rs
@@ -274,7 +274,11 @@ impl TreeListCtrl {
                 return String::new();
             }
         }
-        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len as usize) };
+        // Clamp to the buffer's actual size: if the retry call still reports a
+        // length >= buffer.len() (e.g. the underlying value changed between the
+        // two calls), trusting it verbatim would read past the allocation.
+        let safe_len = (len as usize).min(buffer.len());
+        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, safe_len) };
         String::from_utf8_lossy(byte_slice).to_string()
     }
 

--- a/rust/wxdragon/src/widgets/webview.rs
+++ b/rust/wxdragon/src/widgets/webview.rs
@@ -281,7 +281,11 @@ impl WebView {
                 return String::new();
             }
         }
-        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len as usize) };
+        // Clamp to the buffer's actual size: if the retry call still reports a
+        // length >= buffer.len() (e.g. the underlying value changed between the
+        // two calls), trusting it verbatim would read past the allocation.
+        let safe_len = (len as usize).min(buffer.len());
+        let byte_slice = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, safe_len) };
         String::from_utf8_lossy(byte_slice).to_string()
     }
 


### PR DESCRIPTION
## Problem

`TextCtrl`, `RichTextCtrl`, `StyledTextCtrl`, `TreeListCtrl`, and `WebView` each have their own copy of a getter-with-retry helper: call once with a 1024-byte buffer, and if the C++ side reports a length >= that, reallocate to the exact reported size and call again. The final `slice::from_raw_parts` used the *second* call's reported length directly, with no check that it still fits the (new) buffer.

In the common case the two calls agree (same string, called back to back), so this was never observed to misbehave — but nothing actually guarantees it. If the underlying value can change between the two calls, the second length could still exceed the buffer, and the code would read past the allocation.

(I also looked at `Bitmap::get_rgba_data`'s `width * height * 4` length and the `dataview::model` children-array leak/reclaim pattern, which were flagged in the same category during an earlier audit pass — both turned out to be self-consistent by construction on closer inspection, so I left them alone rather than add a defensive check with nothing real behind it.)

## Fix

Clamp the length to the buffer's actual size before constructing the slice in all 5 copies of the helper — trivial cost, and removes the possibility of an out-of-bounds read entirely rather than relying on the two calls happening to agree.

## Test plan

- [x] `cargo check -p wxdragon --features "aui,xrc,richtext,stc,webview"` passes
- [x] `cargo fmt --check` and `cargo clippy --features "aui,xrc,richtext,stc,webview" -- -D warnings` both clean
- [ ] CI green