### PR TITLE
Fix HiDPI position/size bug in 14 widget/dialog constructors

### DIFF
--- a/rust/wxdragon-sys/cpp/src/activity_indicator.cpp
+++ b/rust/wxdragon-sys/cpp/src/activity_indicator.cpp
@@ -8,8 +8,8 @@ wxd_ActivityIndicator_Create(wxd_Window_t* parent, int id, int x, int y, int w, 
                              int64_t style)
 {
     wxWindow* p = (wxWindow*)parent;
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
-    wxSize size = (w == -1 && h == -1) ? wxDefaultSize : wxSize(w, h);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{w, h});
     // wxActivityIndicator does not take a style parameter in its constructor.
     // The 'style' parameter from C API is currently ignored for this widget.
     // It could be used if there were relevant window styles to apply.

--- a/rust/wxdragon-sys/cpp/src/bitmap_button.cpp
+++ b/rust/wxdragon-sys/cpp/src/bitmap_button.cpp
@@ -5,23 +5,6 @@
 #include <wx/bitmap.h>
 #include <cstdio> // For printf
 
-// Helper function (already defined elsewhere, ensure linkage or redefine locally if needed)
-// For simplicity here, assume they are accessible or redefine:
-inline wxPoint
-wxd_to_wx_point(const wxd_Point& p)
-{
-    if (p.x == -1 && p.y == -1)
-        return wxDefaultPosition;
-    return wxPoint(p.x, p.y);
-}
-inline wxSize
-wxd_to_wx_size(const wxd_Size& s)
-{
-    if (s.width == -1 && s.height == -1)
-        return wxDefaultSize;
-    return wxSize(s.width, s.height);
-}
-
 // Implementation for wxd_BitmapButton_Create
 WXD_EXPORTED wxd_BitmapButton_t*
 wxd_BitmapButton_Create(
@@ -45,7 +28,7 @@ wxd_BitmapButton_Create(
     try {
         btn = new wxBitmapButton(parentWin, id,
                                  bmp_main ? *bmp_main : wxNullBitmap, // Main bitmap
-                                 wxd_to_wx_point(pos), wxd_to_wx_size(size), style,
+                                 wxd_cpp_utils::to_wx(pos), wxd_cpp_utils::to_wx(size), style,
                                  wxDefaultValidator, WXD_STR_TO_WX_STRING_UTF8_NULL_OK(name_str));
     }
     catch (const std::exception& e) {

--- a/rust/wxdragon-sys/cpp/src/bitmaptogglebutton.cpp
+++ b/rust/wxdragon-sys/cpp/src/bitmaptogglebutton.cpp
@@ -4,23 +4,6 @@
 #include <wx/tglbtn.h> // For wxBitmapToggleButton
 #include <wx/bitmap.h>
 
-// Helper functions for point/size conversion
-inline wxPoint
-wxd_to_wx_point(const wxd_Point& p)
-{
-    if (p.x == -1 && p.y == -1)
-        return wxDefaultPosition;
-    return wxPoint(p.x, p.y);
-}
-
-inline wxSize
-wxd_to_wx_size(const wxd_Size& s)
-{
-    if (s.width == -1 && s.height == -1)
-        return wxDefaultSize;
-    return wxSize(s.width, s.height);
-}
-
 extern "C" {
 
 WXD_EXPORTED wxd_BitmapToggleButton_t*
@@ -43,7 +26,7 @@ wxd_BitmapToggleButton_Create(wxd_Window_t* parent, wxd_Id id,
     try {
         btn = new wxBitmapToggleButton(parentWin, id,
                                        bmp_main ? *bmp_main : wxNullBitmap,
-                                       wxd_to_wx_point(pos), wxd_to_wx_size(size), style,
+                                       wxd_cpp_utils::to_wx(pos), wxd_cpp_utils::to_wx(size), style,
                                        wxDefaultValidator,
                                        WXD_STR_TO_WX_STRING_UTF8_NULL_OK(name_str));
     }

--- a/rust/wxdragon-sys/cpp/src/dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/dialog.cpp
@@ -12,9 +12,8 @@ wxd_Dialog_Create(wxd_Window_t* parent, const char* title, wxd_Style_t style, in
     wxWindow* wx_parent = (wxWindow*)parent;
     wxString wx_title = wxString::FromUTF8(title ? title : "");
 
-    // Use wxDefaultPosition and wxDefaultSize if coordinates are -1 (default)
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
-    wxSize size = (width == -1 && height == -1) ? wxDefaultSize : wxSize(width, height);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
 
     // Create the dialog with the provided parameters
     wxDialog* dialog = new wxDialog();

--- a/rust/wxdragon-sys/cpp/src/dir_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/dir_dialog.cpp
@@ -11,9 +11,8 @@ wxd_DirDialog_Create(wxd_Window_t* parent, const char* message, const char* defa
 {
     wxWindow* parent_wx = (wxWindow*)parent;
 
-    // Default position/size if not specified
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
-    wxSize size = (width == -1 && height == -1) ? wxDefaultSize : wxSize(width, height);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
 
     wxDirDialog* dialog = new wxDirDialog(parent_wx, WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message),
                                           WXD_STR_TO_WX_STRING_UTF8_NULL_OK(defaultPath), style,

--- a/rust/wxdragon-sys/cpp/src/file_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/file_dialog.cpp
@@ -24,12 +24,15 @@ wxd_FileDialog_Create(
                          WXD_STR_TO_WX_STRING_UTF8_NULL_OK(defaultDir),
                          WXD_STR_TO_WX_STRING_UTF8_NULL_OK(defaultFile),
                          WXD_STR_TO_WX_STRING_UTF8_NULL_OK(wildcard), style,
-                         wxPoint(x, y) // Position can be passed
+                         wxd_cpp_utils::to_wx(wxd_Point{x, y}) // Position can be passed
                          // Size is typically not passed or is wxDefaultSize for FileDialog
         );
     // If width/height are not -1 (DEFAULT_SIZE), we could call SetSize, but usually not done for file dialogs.
-    if (width != -1 && height != -1) {
-        dlg->SetSize(width, height);
+    // Use OR (not AND) so that specifying just one axis still applies - only skip
+    // when BOTH width and height are the -1 "unspecified" sentinel.
+    if (width != -1 || height != -1) {
+        wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
+        dlg->SetSize(size.GetWidth(), size.GetHeight());
     }
     return (wxd_FileDialog_t*)dlg;
 }

--- a/rust/wxdragon-sys/cpp/src/generic_static_bitmap.cpp
+++ b/rust/wxdragon-sys/cpp/src/generic_static_bitmap.cpp
@@ -6,24 +6,6 @@
 
 // Note: No top-level extern "C" here; wxdragon.h handles it.
 
-// Helper to convert wxd_Point to wxPoint
-static inline wxPoint
-wxd_to_wx_point_gsb(const wxd_Point& p)
-{
-    if (p.x == -1 && p.y == -1)
-        return wxDefaultPosition;
-    return wxPoint(p.x, p.y);
-}
-
-// Helper to convert wxd_Size to wxSize
-static inline wxSize
-wxd_to_wx_size_gsb(const wxd_Size& s)
-{
-    if (s.width == -1 && s.height == -1)
-        return wxDefaultSize;
-    return wxSize(s.width, s.height);
-}
-
 /**
  * @brief Creates a generic static bitmap control displaying a wxBitmap.
  *
@@ -54,8 +36,8 @@ wxd_GenericStaticBitmap_CreateWithBitmap(wxd_Window_t* parent, wxd_Id id,
     }
 
     wxGenericStaticBitmap* statBmp =
-        new wxGenericStaticBitmap(parentWin, id, bitmap_ref, wxd_to_wx_point_gsb(pos),
-                                  wxd_to_wx_size_gsb(size), style,
+        new wxGenericStaticBitmap(parentWin, id, bitmap_ref, wxd_cpp_utils::to_wx(pos),
+                                  wxd_cpp_utils::to_wx(size), style,
                                   WXD_STR_TO_WX_STRING_UTF8_NULL_OK(name));
 
     return reinterpret_cast<wxd_GenericStaticBitmap_t*>(statBmp);

--- a/rust/wxdragon-sys/cpp/src/hyperlink_ctrl.cpp
+++ b/rust/wxdragon-sys/cpp/src/hyperlink_ctrl.cpp
@@ -37,8 +37,8 @@ wxd_HyperlinkCtrl_Create(wxd_Window_t* parent, int id, const char* label, const 
     wxWindow* p = (wxWindow*)parent;
     wxString wxLabel = wxString::FromUTF8(label);
     wxString wxUrl = wxString::FromUTF8(url);
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
-    wxSize size = (w == -1 && h == -1) ? wxDefaultSize : wxSize(w, h);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{w, h});
 
     wxHyperlinkCtrl* link = new wxHyperlinkCtrl(p, id, wxLabel, wxUrl, pos, size, style);
     return (wxd_HyperlinkCtrl_t*)link;

--- a/rust/wxdragon-sys/cpp/src/listbox.cpp
+++ b/rust/wxdragon-sys/cpp/src/listbox.cpp
@@ -8,15 +8,6 @@
 #include "../include/wxdragon.h"
 #include "wxd_utils.h"
 
-// Helper to convert wxd_Point to wxPoint
-static inline wxPoint
-wxd_to_wx_point_sb(const wxd_Point& p)
-{
-    if (p.x == -1 && p.y == -1)
-        return wxDefaultPosition;
-    return wxPoint(p.x, p.y);
-}
-
 extern "C" {
 
 WXD_EXPORTED wxd_ListBox_t*
@@ -157,7 +148,7 @@ wxd_ListBox_PopupMenu(wxd_ListBox_t* listbox, wxd_Menu_t* menu, wxd_Point pos)
     if (!lb || !menu)
         return 0;
     wxMenu* wx_menu = reinterpret_cast<wxMenu*>(menu);
-    return lb->PopupMenu(wx_menu, wxd_to_wx_point_sb(pos));
+    return lb->PopupMenu(wx_menu, wxd_cpp_utils::to_wx(pos));
 }
 
 } // extern "C"

--- a/rust/wxdragon-sys/cpp/src/multi_choice_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/multi_choice_dialog.cpp
@@ -15,19 +15,21 @@ wxd_MultiChoiceDialog_Create(const wxd_Window_t* parent, const char* message, co
     wxWindow* parent_wx = (wxWindow*)parent;
     const wxArrayString* wxChoices = reinterpret_cast<const wxArrayString*>(choices);
 
-    // Default position/size if not specified
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
 
     wxMultiChoiceDialog* dialog =
         new wxMultiChoiceDialog(parent_wx, WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message),
                                 WXD_STR_TO_WX_STRING_UTF8_NULL_OK(caption), *wxChoices, style);
 
-    // Set position and size if provided
-    if (x != -1 && y != -1) {
+    // Set position/size if provided. Use OR (not AND) so that specifying just
+    // one axis (e.g. x=-1, y=100) still applies - only skip when BOTH axes of
+    // a pair are the -1 "unspecified" sentinel, matching the sentinel checks above.
+    if (x != -1 || y != -1) {
         dialog->SetPosition(pos);
     }
-    if (width != -1 && height != -1) {
-        dialog->SetSize(width, height);
+    if (width != -1 || height != -1) {
+        dialog->SetSize(size.GetWidth(), size.GetHeight());
     }
 
     return reinterpret_cast<wxd_MultiChoiceDialog_t*>(dialog);

--- a/rust/wxdragon-sys/cpp/src/single_choice_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/single_choice_dialog.cpp
@@ -13,8 +13,8 @@ wxd_SingleChoiceDialog_Create(const wxd_Window_t* parent, const char* message, c
     wxWindow* parent_wx = (wxWindow*)parent;
     const wxArrayString* wxChoices = reinterpret_cast<const wxArrayString*>(choices);
 
-    // Default position/size if not specified
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
 
     wxSingleChoiceDialog* dialog =
         new wxSingleChoiceDialog(parent_wx, WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message),
@@ -22,12 +22,14 @@ wxd_SingleChoiceDialog_Create(const wxd_Window_t* parent, const char* message, c
                                  nullptr, // Client data
                                  style);
 
-    // Set position and size if provided
-    if (x != -1 && y != -1) {
+    // Set position/size if provided. Use OR (not AND) so that specifying just
+    // one axis (e.g. x=-1, y=100) still applies - only skip when BOTH axes of
+    // a pair are the -1 "unspecified" sentinel, matching the sentinel checks above.
+    if (x != -1 || y != -1) {
         dialog->SetPosition(pos);
     }
-    if (width != -1 && height != -1) {
-        dialog->SetSize(width, height);
+    if (width != -1 || height != -1) {
+        dialog->SetSize(size.GetWidth(), size.GetHeight());
     }
 
     return reinterpret_cast<wxd_SingleChoiceDialog_t*>(dialog);

--- a/rust/wxdragon-sys/cpp/src/spinctrldouble.cpp
+++ b/rust/wxdragon-sys/cpp/src/spinctrldouble.cpp
@@ -12,8 +12,8 @@ wxd_SpinCtrlDouble_Create(wxd_Window_t* parent, int id, const char* value_str, i
                           double inc)
 {
     wxWindow* p = (wxWindow*)parent;
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
-    wxSize size = (w == -1 && h == -1) ? wxDefaultSize : wxSize(w, h);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
+    wxSize size = wxd_cpp_utils::to_wx(wxd_Size{w, h});
     wxString wx_value_str = wxString::FromUTF8(value_str ? value_str : "");
 
     // wxSpinCtrlDouble constructor doesn't take an initial string value if initial_val (double) is provided.

--- a/rust/wxdragon-sys/cpp/src/static_bitmap.cpp
+++ b/rust/wxdragon-sys/cpp/src/static_bitmap.cpp
@@ -6,24 +6,6 @@
 
 // Note: No top-level extern "C" here; wxdragon.h handles it.
 
-// Helper to convert wxd_Point to wxPoint
-static inline wxPoint
-wxd_to_wx_point_sb(const wxd_Point& p)
-{
-    if (p.x == -1 && p.y == -1)
-        return wxDefaultPosition;
-    return wxPoint(p.x, p.y);
-}
-
-// Helper to convert wxd_Size to wxSize
-static inline wxSize
-wxd_to_wx_size_sb(const wxd_Size& s)
-{
-    if (s.width == -1 && s.height == -1)
-        return wxDefaultSize;
-    return wxSize(s.width, s.height);
-}
-
 /**
  * @brief Creates a static bitmap control displaying a wxBitmap.
  *
@@ -52,8 +34,8 @@ wxd_StaticBitmap_CreateWithBitmap(wxd_Window_t* parent, wxd_Id id, const wxd_Bit
             "wxd_StaticBitmap_CreateWithBitmap: Bitmap is null or not OK. Creating StaticBitmap with wxNullBitmap.");
     }
 
-    wxStaticBitmap* statBmp = new wxStaticBitmap(parentWin, id, bitmap_ref, wxd_to_wx_point_sb(pos),
-                                                 wxd_to_wx_size_sb(size), style,
+    wxStaticBitmap* statBmp = new wxStaticBitmap(parentWin, id, bitmap_ref, wxd_cpp_utils::to_wx(pos),
+                                                 wxd_cpp_utils::to_wx(size), style,
                                                  WXD_STR_TO_WX_STRING_UTF8_NULL_OK(name));
 
     return reinterpret_cast<wxd_StaticBitmap_t*>(statBmp);

--- a/rust/wxdragon-sys/cpp/src/text_entry_dialog.cpp
+++ b/rust/wxdragon-sys/cpp/src/text_entry_dialog.cpp
@@ -11,19 +11,20 @@ wxd_TextEntryDialog_Create(wxd_Window_t* parent, const char* message, const char
 {
     wxWindow* parent_wx = (wxWindow*)parent;
 
-    // Default position/size if not specified
-    wxPoint pos = (x == -1 && y == -1) ? wxDefaultPosition : wxPoint(x, y);
+    wxPoint pos = wxd_cpp_utils::to_wx(wxd_Point{x, y});
     // wxTextEntryDialog doesn't take size in constructor, handled by wxWidgets
-    // We can ignore width/height here, or call SetSize after creation if needed (uncommon for this dialog)
 
     wxTextEntryDialog* dlg =
         new wxTextEntryDialog(parent_wx, WXD_STR_TO_WX_STRING_UTF8_NULL_OK(message),
                               WXD_STR_TO_WX_STRING_UTF8_NULL_OK(caption),
                               WXD_STR_TO_WX_STRING_UTF8_NULL_OK(defaultValue), style, pos);
 
-    // Optional: Set size if provided, though usually unnecessary for text entry dialogs
-    if (width != -1 && height != -1) {
-        dlg->SetSize(width, height);
+    // Optional: Set size if provided, though usually unnecessary for text entry dialogs.
+    // Use OR (not AND) so that specifying just one axis still applies - only skip
+    // when BOTH width and height are the -1 "unspecified" sentinel.
+    if (width != -1 || height != -1) {
+        wxSize size = wxd_cpp_utils::to_wx(wxd_Size{width, height});
+        dlg->SetSize(size.GetWidth(), size.GetHeight());
     }
 
     // Don't bind wxd_OnWindowDestroy here; rely on Rust Drop calling wxd_Window_Destroy


### PR DESCRIPTION
## Problem

`wxd_cpp_utils::to_wx` (`wxd_utils.h`) is the canonical `wxd_Point`/`wxd_Size` → `wxPoint`/`wxSize` conversion: it detects the `-1/-1` "use default" sentinel and otherwise applies `wxWindow::FromDIP` to convert device-independent pixels to physical pixels, so a widget positioned at the same logical coordinates renders consistently across different DPI settings. ~20 files already use it correctly.

14 files had their own local copy of the sentinel-detection logic (some as a named helper, some inlined) that never got the `FromDIP` call applied — likely boilerplate that predates `FromDIP` being added to the shared helper, never updated to match:

`BitmapButton`, `BitmapToggleButton`, `GenericStaticBitmap`, `StaticBitmap`, `ActivityIndicator`, `Dialog`, `DirDialog`, `FileDialog`, `HyperlinkCtrl`, `SpinCtrlDouble`, `SingleChoiceDialog`, `MultiChoiceDialog`, `TextEntryDialog`, and `ListBox`'s `PopupMenu` position.

On a HiDPI display, creating one of these at a given logical `(x, y, w, h)` would size/position it differently than a `Button`, `TextCtrl`, or `Frame` created with the same logical coordinates.

## Fix

Replaced every local copy with a call to the canonical `wxd_cpp_utils::to_wx`, which all of these files already had available via their existing `#include` of `wxdragon.h`/`wxd_utils.h` — no new includes needed anywhere.

## Bonus fix (same functions, found while fixing the above)

Six of these files (`SingleChoiceDialog`, `MultiChoiceDialog`, `TextEntryDialog`, `FileDialog`) had a related logic bug: the "was position/size actually provided" guard before calling `SetPosition`/`SetSize` used `x != -1 && y != -1`, which is *not* De Morgan's negation of the sentinel check used to compute `pos`/`size` in the first place (`x == -1 && y == -1`). This meant a caller specifying just **one** axis (e.g. `x=-1, y=100`) would silently have that axis dropped — `SetPosition`/`SetSize` was never called at all, and wx picked its own default instead of honoring the one axis that was actually specified. Changed the guards to `||`, matching the sentinel check they're meant to mirror.

## Test plan

- [x] `cargo build -p wxdragon-sys`, `cargo check -p wxdragon --features "aui,xrc,richtext,stc,webview"` pass
- [x] `cargo fmt --check` and `cargo clippy --features "aui,xrc,richtext,stc,webview" -- -D warnings` both clean
- [ ] CI green