### PR TITLE
Expose DataViewListCtrl selection and visibility helpers

### DIFF
--- a/rust/wxdragon/src/widgets/dataview/list_ctrl.rs
+++ b/rust/wxdragon/src/widgets/dataview/list_ctrl.rs
@@ -188,6 +188,17 @@ impl DataViewListCtrl {
         unsafe { ffi::wxd_DataViewCtrl_UnselectAll(ptr) }
     }
 
+    /// Selects all rows in the control.
+    ///
+    /// This is only meaningful when the control uses [`DataViewStyle::Multiple`].
+    pub fn select_all(&self) {
+        let ptr = self.dvlc_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_DataViewCtrl_SelectAll(ptr) }
+    }
+
     // ==========================================================================
     // Item Count
     // ==========================================================================
@@ -463,6 +474,28 @@ impl DataViewListCtrl {
         } else {
             Some(DataViewItem::from(item_ptr as *const _))
         }
+    }
+
+    /// Sets the item that has keyboard focus.
+    ///
+    /// The item can be obtained from a row index with [`Self::row_to_item`].
+    pub fn set_current_item(&self, item: &DataViewItem) {
+        let ptr = self.dvlc_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_DataViewCtrl_SetCurrentItem(ptr, **item) }
+    }
+
+    /// Ensures that the given item is visible, scrolling the control if necessary.
+    ///
+    /// The item can be obtained from a row index with [`Self::row_to_item`].
+    pub fn ensure_visible(&self, item: &DataViewItem) {
+        let ptr = self.dvlc_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        unsafe { ffi::wxd_DataViewCtrl_EnsureVisible(ptr, **item) }
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary

- expose `select_all` on `DataViewListCtrl`
- expose `set_current_item` and `ensure_visible` for item focus and scrolling
- preserve `DataViewListCtrl`'s null-handle safety checks

These operations already exist in wxDragon's C ABI and on the generic `DataViewCtrl`; this change makes them available through the safe `DataViewListCtrl` API as well.

## Motivation

Consumers using the native data-view list currently need direct FFI calls to select all rows, set the keyboard-focused item, or scroll an item into view. In particular, Paperback uses `DataViewListCtrl` on macOS because it exposes the document list correctly to VoiceOver.

## Validation

- `cargo fmt --check`
- `cargo check -p wxdragon`
- `cargo clippy -p wxdragon -- -D warnings`
- `cargo test -p wxdragon --lib` (7 passed, 1 ignored)
