### PR TITLE
feat(sys): download wxWidgets into an absent custom WXWIDGETS_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **ListCtrl**: Fixed `get_item_text` truncating the last character and replacing it with a NUL byte; multi-byte UTF-8 text is no longer corrupted (#205)
 
+### Build
+
+- Download wxWidgets into a custom `WXWIDGETS_DIR` when the directory does not exist yet or is empty (#207)
+
 ## 0.9.19
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Cross-compilation is supported, including building Windows executables from macO
 > Since wxDragon's builder downloads wxWidgets source code from GitHub using git's proxy settings,
 > applying the proxy will help avoid download issues.
 
+> The wxWidgets source and the two CMake build trees default to the profile level of the target directory.
+> `WXWIDGETS_DIR`, `WXWIDGETS_BUILD_DIR` and `WXDRAGON_SYS_BUILD_DIR` move them elsewhere, for example to a
+> directory a CI cache preserves; see the [wxdragon-sys README](rust/wxdragon-sys/README.md#build-process).
+
 **Linux Additional Requirements:**
 ```bash
 # Ubuntu/Debian

--- a/rust/wxdragon-sys/README.md
+++ b/rust/wxdragon-sys/README.md
@@ -16,11 +16,19 @@ This crate provides raw FFI (Foreign Function Interface) bindings to `libwxdrago
 
 The build process (`build.rs`) for this crate performs the following key steps:
 
-1.  **Downloads wxWidgets**: Fetches the wxWidgets 3.2.4 source tarball.
+1.  **Downloads wxWidgets**: Fetches the wxWidgets 3.3.3 source archive.
 2.  **Extracts wxWidgets**: Decompresses and extracts the sources.
 3.  **Builds wxWidgets**: Compiles wxWidgets as a static library using CMake.
 4.  **Builds libwxdragon**: Compiles the `wxdragon` C++ wrapper code (found in the `src` directory of the main project) which links against the just-built wxWidgets. This also becomes a static library.
 5.  **Generates Bindings**: Uses `bindgen` to generate Rust FFI bindings from the `include/wxdragon.h` header file.
+
+The directories involved can be moved through environment variables, for example to a location a CI cache preserves:
+
+- `WXWIDGETS_DIR`: the wxWidgets source tree (default: `<target>/<profile>/wxWidgets`). An existing directory is used as-is; an absent or empty one receives the download.
+- `WXWIDGETS_BUILD_DIR`: the wxWidgets CMake build tree (default: `<target>/<profile>/wxwidgets_cmake_build`).
+- `WXDRAGON_SYS_BUILD_DIR`: the libwxdragon CMake build tree (default: `<target>/<profile>/wxdragon_sys_cmake_build`).
+
+Changing any of them re-runs the build script.
 
 ## Usage
 

--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -60,7 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .find(|p| p.file_name().map(|n| *n == *profile).unwrap_or(false))
         .expect("Could not find destination binary directory");
 
-    // wxWidgets source download location (shared per profile to avoid re-downloading)
+    // wxWidgets source download location (shared per profile to avoid re-downloading).
+    // A custom WXWIDGETS_DIR is used as-is when it holds a tree and receives the
+    // download when it is absent or empty; the default location is replaced whenever
+    // its version does not match.
     let wxwidgets_dir = std::env::var("WXWIDGETS_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| dest_bin_dir.join("wxWidgets"));
@@ -69,8 +72,18 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
     let is_custom_dir = std::env::var("WXWIDGETS_DIR").is_ok();
     let ver_matched = chk_wx_version(&wxwidgets_dir, WX_VERSION).unwrap_or(false);
-    if !is_custom_dir && !ver_matched {
-        std::fs::remove_dir_all(&wxwidgets_dir).ok();
+    let should_download = if is_custom_dir {
+        !wxwidgets_dir.exists() || dir_is_empty(&wxwidgets_dir)
+    } else {
+        !ver_matched
+    };
+    if is_custom_dir && !should_download && !ver_matched {
+        println!("cargo::warning=WXWIDGETS_DIR={wxwidgets_dir_str} does not contain wxWidgets {WX_VERSION}; using it as-is");
+    }
+    if should_download {
+        if !is_custom_dir {
+            std::fs::remove_dir_all(&wxwidgets_dir).ok();
+        }
 
         let archive_dest_path = std::env::temp_dir().join("wxWidgets.zip");
 
@@ -1222,6 +1235,12 @@ where
     }
 
     Ok(())
+}
+
+fn dir_is_empty<P: AsRef<std::path::Path>>(dir: P) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
 }
 
 fn chk_wx_version<P: AsRef<std::path::Path>>(wxwidgets_dir: P, expected_version: &str) -> std::io::Result<bool> {


### PR DESCRIPTION
The build script downloads the wxWidgets source into the profile level of cargo's target directory. `WXWIDGETS_DIR` points it at another directory instead. Today a directory given that way is treated as a user-supplied source tree: the build script never downloads into it, whatever its state.

CI caches need the source to be relocatable, the same way #183 made the two CMake build trees relocatable. Pointing `WXWIDGETS_DIR` at a directory the cache preserves fails on the first run, before the cache holds anything: there is no source, and bindgen stops on the missing headers. Without the source in the cache, every rerun of the build script downloads it again with fresh timestamps, and Ninja rebuilds the whole of wxWidgets even though the cached build trees are intact.

This change downloads into a custom directory when it does not exist yet or is empty. A custom directory that holds a tree is still used as-is and is never removed, so a user-supplied checkout keeps working exactly as before. When such a tree does not carry the expected wxWidgets version, the build script now prints a warning; previously the mismatch only surfaced as a bindgen failure. The default location keeps its behaviour: it is replaced whenever its version does not match.

The `wxdragon-sys` README documents the three directory variables (`WXWIDGETS_DIR`, `WXWIDGETS_BUILD_DIR`, `WXDRAGON_SYS_BUILD_DIR`) and their defaults, and the main README points to that section. The stale mention of a 3.2.4 tarball is corrected to the 3.3.3 archive the script fetches.

Verified locally on Windows (MSVC) with the build directories pointed at a scratch location: an absent custom directory receives the download and the build succeeds; a second build against the populated directory downloads nothing and leaves wxWidgets untouched; an empty directory receives the download; a directory holding a foreign file is left untouched and gets the new warning; without the variable, the default location behaves as before.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
