### PR TITLE
feat(sys): preserve source timestamps when extracting wxWidgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **ListCtrl**: Fixed `get_item_text` truncating the last character and replacing it with a NUL byte; multi-byte UTF-8 text is no longer corrupted (#205)
 
+### Build
+
+- Preserve the file timestamps of the wxWidgets source when extracting the archive, so a re-downloaded source no longer triggers a full wxWidgets rebuild (#208)
+
 ## 0.9.19
 
 ### New Features

--- a/rust/wxdragon-sys/build.rs
+++ b/rust/wxdragon-sys/build.rs
@@ -1219,9 +1219,29 @@ where
                 println!("cargo:warning=Unsupported compression method {method:?} for file: {file_path:?}");
             }
         }
+        if let Some(secs) = entry_unix_time(&entry.last_modified())
+            && secs > 0
+        {
+            let modified = std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs as u64);
+            outfile.set_modified(modified).ok();
+        }
     }
 
     Ok(())
+}
+
+/// Reads either timestamp kind as UTC.
+fn entry_unix_time(kind: &rawzip::time::ZipDateTimeKind) -> Option<i64> {
+    rawzip::time::UtcDateTime::from_components(
+        kind.year(),
+        kind.month(),
+        kind.day(),
+        kind.hour(),
+        kind.minute(),
+        kind.second(),
+        0,
+    )
+    .map(|t| t.to_unix())
 }
 
 fn chk_wx_version<P: AsRef<std::path::Path>>(wxwidgets_dir: P, expected_version: &str) -> std::io::Result<bool> {


### PR DESCRIPTION
The build script extracts the wxWidgets source archive with a small zip reader of its own. Every extracted file gets the current time as its modification time.

Ninja rebuilds an object whenever one of its inputs is newer than it. A source tree extracted after the last build is therefore newer than every object, and the whole of wxWidgets compiles again even though the CMake build trees are intact. That happens whenever the source is downloaded again while the build trees survive: a bumped `wxdragon-sys`, a CI cache that kept the build trees but not the source, or a source directory deleted to save space.

The archive carries the timestamps of the release. This change writes them onto the extracted files, so a freshly extracted source is older than any object built from it, and Ninja leaves the build alone. Both timestamp kinds a zip can carry, UTC and local, are read as UTC; a difference of a few hours does not matter for a comparison against objects built later. A file whose timestamp cannot be represented keeps the current time, and a failure to set the time is ignored, so extraction never fails because of this.

Verified locally on Windows (MSVC): after a fresh build, the extracted files carry the timestamps of the 3.3.3 release; deleting the source directory and building again downloads and extracts it anew, and the wxWidgets build step reports no work to do.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
