### PR TITLE
Add wxWindow::FromDIP/ToDIP to the WxWidget trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - **ComboBox**: Added the remaining `wxTextEntry` and `wxItemContainer` methods (`change_value`, `write_text`, `delete`, `find_string`, `set_items`, ...), `popup` / `dismiss`, and the `DROPDOWN` / `CLOSEUP` events (#209)
+- **Window**: Added `from_dip`/`to_dip` (plus `_int` and `_point` variants) wrapping `wxWindow::FromDIP`/`ToDIP`, for converting between the device-independent pixels UI sizes are written in and the physical pixels a per-monitor DPI aware app is handed (#210)
 
 ## 0.9.20
 

--- a/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
+++ b/rust/wxdragon-sys/cpp/include/core/wxd_window_base.h
@@ -53,6 +53,22 @@ wxd_Window_ClientToScreen(wxd_Window_t* window, wxd_Point pt);
 WXD_EXPORTED wxd_Point
 wxd_Window_ScreenToClient(wxd_Window_t* window, wxd_Point pt);
 
+// DPI scaling: convert between device-independent pixels (what a size is written as at
+// 100% scaling) and the physical pixels wx works in, using the DPI of the display the
+// window is actually on. A null window leaves the value unchanged.
+WXD_EXPORTED int
+wxd_Window_FromDIPInt(wxd_Window_t* window, int value);
+WXD_EXPORTED wxd_Size
+wxd_Window_FromDIPSize(wxd_Window_t* window, wxd_Size size);
+WXD_EXPORTED wxd_Point
+wxd_Window_FromDIPPoint(wxd_Window_t* window, wxd_Point pt);
+WXD_EXPORTED int
+wxd_Window_ToDIPInt(wxd_Window_t* window, int value);
+WXD_EXPORTED wxd_Size
+wxd_Window_ToDIPSize(wxd_Window_t* window, wxd_Size size);
+WXD_EXPORTED wxd_Point
+wxd_Window_ToDIPPoint(wxd_Window_t* window, wxd_Point pt);
+
 // Declarations for functions that were previously in wxdragon.h directly
 WXD_EXPORTED void
 wxd_Window_Show(wxd_Window_t* self, bool show);

--- a/rust/wxdragon-sys/cpp/src/window.cpp
+++ b/rust/wxdragon-sys/cpp/src/window.cpp
@@ -442,6 +442,74 @@ wxd_Window_ScreenToClient(wxd_Window_t* window, wxd_Point pt)
     return { wx_result.x, wx_result.y };
 }
 
+// DPI scaling conversions. A null window leaves the value unchanged rather than falling back
+// to wx's static overloads, which resolve against the primary display: silently sizing for the
+// wrong monitor is harder to notice than a value that was left alone.
+
+WXD_EXPORTED int
+wxd_Window_FromDIPInt(wxd_Window_t* window, int value)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return value;
+    }
+    return wx_window->FromDIP(value);
+}
+
+WXD_EXPORTED wxd_Size
+wxd_Window_FromDIPSize(wxd_Window_t* window, wxd_Size size)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return size;
+    }
+    wxSize wx_result = wx_window->FromDIP(wxSize(size.width, size.height));
+    return { wx_result.GetWidth(), wx_result.GetHeight() };
+}
+
+WXD_EXPORTED wxd_Point
+wxd_Window_FromDIPPoint(wxd_Window_t* window, wxd_Point pt)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return pt;
+    }
+    wxPoint wx_result = wx_window->FromDIP(wxPoint(pt.x, pt.y));
+    return { wx_result.x, wx_result.y };
+}
+
+WXD_EXPORTED int
+wxd_Window_ToDIPInt(wxd_Window_t* window, int value)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return value;
+    }
+    return wx_window->ToDIP(value);
+}
+
+WXD_EXPORTED wxd_Size
+wxd_Window_ToDIPSize(wxd_Window_t* window, wxd_Size size)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return size;
+    }
+    wxSize wx_result = wx_window->ToDIP(wxSize(size.width, size.height));
+    return { wx_result.GetWidth(), wx_result.GetHeight() };
+}
+
+WXD_EXPORTED wxd_Point
+wxd_Window_ToDIPPoint(wxd_Window_t* window, wxd_Point pt)
+{
+    wxWindow* wx_window = reinterpret_cast<wxWindow*>(window);
+    if (!wx_window) {
+        return pt;
+    }
+    wxPoint wx_result = wx_window->ToDIP(wxPoint(pt.x, pt.y));
+    return { wx_result.x, wx_result.y };
+}
+
 // Extra window style functions
 WXD_EXPORTED void
 wxd_Window_SetExtraStyle(wxd_Window_t* window, int64_t exStyle)

--- a/rust/wxdragon/src/window.rs
+++ b/rust/wxdragon/src/window.rs
@@ -688,6 +688,104 @@ pub trait WxWidget: std::any::Any {
         }
     }
 
+    /// Converts a size from device-independent pixels to physical pixels, for the display this
+    /// window is on.
+    ///
+    /// Sizes hardcoded in UI code are written for a display at 100% scaling. On a per-monitor
+    /// DPI aware application nothing scales them automatically, so a dialog asked for 800x600
+    /// is 800x600 physical pixels: two thirds of its intended size on a 150% display. Passing
+    /// every such size through here is what keeps a layout the size it was designed to be, on
+    /// whichever monitor the window happens to be on.
+    ///
+    /// This is `wxWindow::FromDIP`. On platforms that hand wx logical coordinates already
+    /// (GTK, macOS) it returns its input unchanged, so it is safe to apply unconditionally.
+    ///
+    /// ```no_run
+    /// # use wxdragon::prelude::*;
+    /// # fn example(parent: &Frame) {
+    /// let size = parent.from_dip(Size::new(400, 300));
+    /// let list = ListCtrl::builder(parent).with_size(size).build();
+    /// # }
+    /// ```
+    // Named for `wxWindow::FromDIP`, which every other method here mirrors too; clippy reads
+    // the `from_` prefix as a constructor.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_dip(&self, size: Size) -> Size {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return size;
+        }
+        let converted = unsafe { ffi::wxd_Window_FromDIPSize(handle, size.into()) };
+        Size {
+            width: converted.width,
+            height: converted.height,
+        }
+    }
+
+    /// [`from_dip`](WxWidget::from_dip) for a single value, e.g. a sizer's border width.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_dip_int(&self, value: i32) -> i32 {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return value;
+        }
+        unsafe { ffi::wxd_Window_FromDIPInt(handle, value) }
+    }
+
+    /// [`from_dip`](WxWidget::from_dip) for a point.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_dip_point(&self, point: Point) -> Point {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return point;
+        }
+        let converted = unsafe { ffi::wxd_Window_FromDIPPoint(handle, point.into()) };
+        Point {
+            x: converted.x,
+            y: converted.y,
+        }
+    }
+
+    /// Converts a size from physical pixels back to device-independent pixels, the inverse of
+    /// [`from_dip`](WxWidget::from_dip).
+    ///
+    /// This is `wxWindow::ToDIP`. Useful for storing a user-resized window's geometry in a
+    /// config file, so it restores to the same apparent size on a display with different
+    /// scaling.
+    fn to_dip(&self, size: Size) -> Size {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return size;
+        }
+        let converted = unsafe { ffi::wxd_Window_ToDIPSize(handle, size.into()) };
+        Size {
+            width: converted.width,
+            height: converted.height,
+        }
+    }
+
+    /// [`to_dip`](WxWidget::to_dip) for a single value.
+    fn to_dip_int(&self, value: i32) -> i32 {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return value;
+        }
+        unsafe { ffi::wxd_Window_ToDIPInt(handle, value) }
+    }
+
+    /// [`to_dip`](WxWidget::to_dip) for a point.
+    fn to_dip_point(&self, point: Point) -> Point {
+        let handle = self.handle_ptr();
+        if handle.is_null() {
+            return point;
+        }
+        let converted = unsafe { ffi::wxd_Window_ToDIPPoint(handle, point.into()) };
+        Point {
+            x: converted.x,
+            y: converted.y,
+        }
+    }
+
     /// Sets the window's size.
     fn set_size(&self, size: Size) {
         let handle = self.handle_ptr();


### PR DESCRIPTION
Sizes hardcoded in UI code are written for a display at 100% scaling. A per-monitor DPI aware app is told nothing will be scaled for it, so those numbers reach wx as physical pixels: a dialog asked for 800x600 opens at two thirds of its intended size on a 150% display, and its text and controls no longer fit the space they were laid out for.

`wxWindow::FromDIP` is the conversion for that, and wxDragon didn't expose it. Downstream apps either shipped the wrong sizes or rebuilt the conversion on `wxDisplay::GetPPI` themselves — the second is what [wx-utils](https://github.com/trypsynth/wx-utils) ended up doing, and it can drop that module once this lands.

**API** (on `WxWidget`, so every widget has it):

```rust
let size = parent.from_dip(Size::new(400, 300));
let list = ListCtrl::builder(parent).with_size(size).build();
```

- `from_dip` / `to_dip` for `Size`
- `from_dip_point` / `to_dip_point` for `Point`
- `from_dip_int` / `to_dip_int` for a single value, e.g. a sizer border

The suffixed variants exist because C has no overloading, so the three `FromDIP` overloads need three exported symbols. `to_dip` is the inverse, for storing a resized window's geometry in a config file so it restores to the same apparent size on a differently-scaled display.

A null window returns its input unchanged rather than falling back to wx's static overloads, which resolve against the primary display — silently sizing for the wrong monitor is harder to notice than a value that was left alone. On GTK and macOS, where wx already works in logical coordinates, `FromDIP` is identity, so this is safe to apply unconditionally.

`from_dip*` carries `#[allow(clippy::wrong_self_convention)]`: clippy reads the `from_` prefix as a constructor, but the name mirrors `wxWindow::FromDIP` the way every other method in this trait mirrors its wx counterpart.

Verified by building `wxdragon` and `wxdragon-sys` locally on Windows/MSVC: the bindgen output picks up all six new declarations, clippy is clean, and fmt is clean.