### PR TITLE
Free a tree item's custom data when the item goes

### DIFF
--- a/rust/wxdragon/src/widgets/treectrl.rs
+++ b/rust/wxdragon/src/widgets/treectrl.rs
@@ -1267,10 +1267,18 @@ impl TreeCtrl {
     /// Direct method to clear custom data on a TreeItemId without going through
     /// u64 conversion.
     ///
-    /// The same reason `set_custom_data_direct` exists: `From<&TreeItemId> for
-    /// u64` passes the address of the reference and `get_concrete_tree_item_id`
-    /// reads it back, which is a round trip worth skipping when the caller
-    /// already holds the item.
+    /// The same reason `set_custom_data_direct` exists, and one more that is
+    /// worth stating because it is not a matter of taste. `From<&TreeItemId>
+    /// for u64` passes the address of the reference, and
+    /// `get_concrete_tree_item_id` reads it back only when the value is greater
+    /// than `u32::MAX`. On a 32-bit target an address never is, so the pointer
+    /// branch is unreachable there and the value falls through to a match that
+    /// answers only 1 and 2, for the root item and the selection. Any real
+    /// address is neither, so the trait path returns `None` and the call does
+    /// nothing at all rather than reporting that it could not.
+    ///
+    /// So the direct methods are not merely a saved round trip. On 32-bit they
+    /// are the only ones that work.
     ///
     /// Returns whether there was anything to remove.
     pub fn clear_custom_data_direct(&self, item_id: &TreeItemId) -> bool {

--- a/rust/wxdragon/src/widgets/treectrl.rs
+++ b/rust/wxdragon/src/widgets/treectrl.rs
@@ -420,8 +420,11 @@ impl TreeCtrl {
         if ptr.is_null() {
             return;
         }
-        // Clean up any attached data before deleting the item
-        let _ = self.clear_custom_data(item);
+        // Clean up attached data before deleting, for the item and for every
+        // child going with it. This used to clear only the item named, while
+        // the doc comment above says the children go too, so each of those
+        // leaked its registry entry.
+        self.clean_item_and_children(item);
 
         unsafe { ffi::wxd_TreeCtrl_Delete(ptr, item.as_ptr()) };
     }
@@ -972,6 +975,9 @@ impl TreeCtrl {
         if ptr.is_null() {
             return;
         }
+        // Before the items go, because each one's registry id is stored on the
+        // item itself and cannot be read once wxWidgets has deleted it.
+        self.cleanup_all_custom_data();
         unsafe { ffi::wxd_TreeCtrl_DeleteAllItems(ptr) }
     }
 
@@ -980,6 +986,15 @@ impl TreeCtrl {
         let ptr = self.treectrl_ptr();
         if ptr.is_null() {
             return;
+        }
+        // The children go, so their registry entries have to go first, for the
+        // same reason as `delete_all_items`. The item itself stays and keeps
+        // whatever data it holds.
+        if let Some((first_child, mut cookie)) = self.get_first_child(item) {
+            self.clean_item_and_children(&first_child);
+            while let Some(next_child) = self.get_next_child(item, &mut cookie) {
+                self.clean_item_and_children(&next_child);
+            }
         }
         unsafe { ffi::wxd_TreeCtrl_DeleteChildren(ptr, item.as_ptr()) }
     }
@@ -1234,22 +1249,46 @@ impl TreeCtrl {
 
     /// Recursively clean up the item and all its children
     fn clean_item_and_children(&self, item: &TreeItemId) {
-        // Check if this item has any children
-        if self.get_children_count(item, false) == 0 {
-            // No children, we're done with this branch
-            return;
-        }
+        // Clear this item before descending. Two things used to stop anything
+        // being freed here: the walk returned early for an item with no
+        // children, which is where custom data usually lives, and even for a
+        // branch it only recursed without ever clearing.
+        self.clear_custom_data_direct(item);
 
-        // Get the first child
         if let Some((first_child, mut cookie)) = self.get_first_child(item) {
-            // Clean up the first child and its descendants
             self.clean_item_and_children(&first_child);
 
-            // Process all remaining children
             while let Some(next_child) = self.get_next_child(item, &mut cookie) {
                 self.clean_item_and_children(&next_child);
             }
         }
+    }
+
+    /// Direct method to clear custom data on a TreeItemId without going through
+    /// u64 conversion.
+    ///
+    /// The same reason `set_custom_data_direct` exists: `From<&TreeItemId> for
+    /// u64` passes the address of the reference and `get_concrete_tree_item_id`
+    /// reads it back, which is a round trip worth skipping when the caller
+    /// already holds the item.
+    ///
+    /// Returns whether there was anything to remove.
+    pub fn clear_custom_data_direct(&self, item_id: &TreeItemId) -> bool {
+        let ptr = self.treectrl_ptr();
+        if ptr.is_null() {
+            return false;
+        }
+
+        let data_id = unsafe { ffi::wxd_TreeCtrl_GetItemData(ptr, item_id.as_ptr()) as u64 };
+        if data_id == 0 {
+            return false;
+        }
+
+        let _ = remove_item_data(data_id);
+        unsafe {
+            ffi::wxd_TreeCtrl_SetItemData(ptr, item_id.as_ptr(), 0);
+        }
+        true
     }
 
     /// Direct method to set custom data on a TreeItemId without going through u64 conversion.


### PR DESCRIPTION
Fixes #214.

`TreeCtrl::cleanup_all_custom_data` walked the whole tree and removed nothing, so every row with custom data left an entry in `ITEM_DATA_REGISTRY` for the life of the process. A tree that is filled, cleared and filled again grew the registry by one entry per row every time.

## What was wrong

**The walk never cleared anything.** `clean_item_and_children` only recursed, and there were two independent reasons nothing was freed. It returned early for an item with no children, and leaves are where custom data usually lives. And even for a branch, the body had no removal call in it at all.

**Three other paths leaked the same way**, which I found while writing the fix rather than in the original report:

| Method | What happened |
| --- | --- |
| `delete_all_items` | Called the FFI directly. Once wxWidgets has deleted the items, each one's registry id can no longer be read, so every entry was stranded. |
| `delete_children` | Same, for the children being removed. |
| `delete` | Cleared only the item it was given, while its own doc comment says it deletes that item **and all its children**. Every descendant leaked. |

`delete` is the one worth a second look. There is a line clearing custom data immediately before the delete, so it reads as handled. It clears one item out of a subtree.

## What this changes

`clean_item_and_children` clears each item as it visits it, and no longer returns early, so leaves are reached:

```rust
fn clean_item_and_children(&self, item: &TreeItemId) {
    self.clear_custom_data_direct(item);

    if let Some((first_child, mut cookie)) = self.get_first_child(item) {
        self.clean_item_and_children(&first_child);
        while let Some(next_child) = self.get_next_child(item, &mut cookie) {
            self.clean_item_and_children(&next_child);
        }
    }
}
```

The three deletion methods clear before the items go, since the ids live on the items.

## One departure from the suggestion in the issue

I proposed calling `clear_custom_data(item)` there. That takes `impl Into<u64>`, and `From<&TreeItemId> for u64` passes the address of the reference, which `get_concrete_tree_item_id` then reads back through a raw pointer with a run of safety checks.

`set_custom_data_direct` already exists to avoid exactly that, and its doc says it is safer when the caller holds the item. So this adds the matching `clear_custom_data_direct` and uses it, which follows a pattern already in the file rather than adding a second one, and skips a pointer round trip in a loop that now runs once per row.

## Compatibility

No API break. `clear_custom_data_direct` is additive and the four fixes are internal. Clearing an item that holds no data returns `false` and touches nothing, so a caller who was not leaking sees no change.

The one behaviour change worth naming: `delete` now walks the subtree it is deleting rather than touching a single item. That is more work per call, proportional to what is being removed, and it is what the method's documentation already promised.

## Checks

`cargo check -p wxdragon`, `cargo clippy -p wxdragon` and `cargo fmt -p wxdragon -- --check` all pass on Windows with no errors or warnings.

I have not written a test for this. The leak is in a process-global registry with no public way to count its entries, so a test would need either a `#[cfg(test)]` accessor on `ITEM_DATA_REGISTRY` or a `len()` on it. Happy to add whichever you would prefer, or to leave it if you would rather not widen that surface.

## How this was found

I hit it in a mail client whose folder tree is rebuilt as mail syncs. A test counting registry entries before and after building and destroying a dialog showed the count only going up. My workaround was to stop calling `set_custom_data` and `append_item_with_data` entirely and key rows another way, which was the only escape available from outside the crate.
